### PR TITLE
docs: update documentation for merge #18 changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,11 +16,11 @@ cmd/game              # Point d'entrée
     /domain           # Cœur métier (pur, testable)
         README.md     # Documentation des patterns
         game.go       # Ré-export des types
-        system.go     # World, Systems, Engine
-        /board        # Plateau, tuiles, positions
-        /entity       # Identités, Manager
+        system.go     # World, Systems, Engine (CreatureAISystem, CreatureMovementSystem)
+        /board        # Plateau, grilles, positions (gère la géométrie)
+        /entity       # Identités, Manager, États (TileState, Type)
         /component    # Données ECS (Lifecycle, Matchable...)
-        /creature     # Créatures et IA
+        /creature     # Créatures, IA et mouvements avancés
         /resource     # Ressources récoltables
         /event        # Bus d'événements
         /player       # Stats, inventaire
@@ -65,6 +65,33 @@ cmd/game              # Point d'entrée
 - Les règles métier (associations, maturation...)
 - Les tests unitaires
 
+**Architecture interne :**
+
+Le domaine utilise une architecture **Entity-Component-System (ECS)** améliorée :
+
+- **Entities** : Chaque entité (créature, ressource, structure, piège) possède :
+  - Un identifiant unique (ID)
+  - Une position sur la grille
+  - Un état (TileState : Hidden, Revealed, Matched, Blocked)
+  - Des composants optionnels (Lifecycle, Matchable, CreatureAI, etc.)
+
+- **Board/Grid** : Gère la géométrie du plateau
+  - Chaque tuile contient une référence optionnelle à une entité
+  - Les tuiles ne portent plus d'état ; c'est l'entité qui le porte
+  - Permet la recherche rapide des entités par position
+
+- **Systems** : Mettent à jour l'état du monde
+  - **CreatureAISystem** : Gère les comportements de base des créatures
+  - **CreatureMovementSystem** : Implémente le système de mouvement avancé (triggers, navigation, modes)
+  - **ResourceLifecycleSystem** : Gère la maturation des ressources
+
+- **Types d'entités** :
+  - `TypeResource` : Ressources récoltables
+  - `TypeCreature` : Créatures avec IA
+  - `TypeStructure` : Structures fixes (terriers, etc.)
+  - `TypeArtefact` : Objets spéciaux
+  - `TypeTrap` : Pièges / tuiles vides
+
 ```go
 // Exemple: Créer un monde et spawner des entités
 world := domain.NewWorld(6, 6)
@@ -74,7 +101,7 @@ world.SpawnCreature("lumifly", domain.Position{X: 3, Y: 3})
 
 ### 2. Usecase (Actions)
 
-Encapsule les actions joueur en Commandes :
+Encapsule les actions joueur en Commandes. Les commandes manipulent les entités et mettent à jour leur état :
 
 ```go
 revealCmd := &usecase.RevealTileCommand{
@@ -82,13 +109,23 @@ revealCmd := &usecase.RevealTileCommand{
     Position: board.Position{X: x, Y: y},
 }
 if revealCmd.CanExecute() {
-    revealCmd.Execute()
+    entity, err := revealCmd.Execute() // Retourne l'entité révélée
 }
 ```
+
+**Commandes principales :**
+- `RevealTileCommand` : Révèle une entité (passe son état de Hidden à Revealed)
+- `MatchTilesCommand` : Appaire deux entités (passe leur état à Matched)
+- `SwitchGridCommand` : Change de grille active
 
 ### 3. Infrastructure
 
 - **Assets**: Cache d'images, génération de placeholders
+  - Génération procédurale des tuiles avec thèmes visuels
+  - Thèmes disponibles : Default (bleu-violet), Forest (forestier), Cave (obscur), etc.
+  - Motifs visuels différents pour chaque état (`Hidden`, `Revealed`, `Matched`)
+  - TODO: Remplacer par des assets finaux avant release
+  
 - **Loader**: Configuration depuis JSON (avec fallback par défaut)
 
 ### 4. UI

--- a/assets/README.md
+++ b/assets/README.md
@@ -8,13 +8,13 @@ finaux (sprites, pixel art, illustrations) avant la release.
 
 ## Statut des Assets
 
-| Type | Statut | Priorité de remplacement |
-|------|--------|-------------------------|
-| Tuiles | 🟡 Temporaire | Moyenne |
-| Ressources | 🟡 Temporaire | Haute |
-| Créatures | 🟡 Temporaire | Haute |
-| Effets de flip | 🟡 Temporaire | Basse |
-| Audio | 🟡 Temporaire | Moyenne |
+| Type | Statut | Priorité | Notes |
+|------|--------|----------|-------|
+| Tuiles avec thèmes | 🟡 Temporaire | Moyenne | Thèmes : Default, Forest, Cave |
+| Ressources | 🟡 Temporaire | Haute | Génération procédurale |
+| Créatures | 🟡 Temporaire | Haute | Génération procédurale |
+| Effets de flip | 🟡 Temporaire | Basse | États : Hidden, Revealed, Matched |
+| Audio | 🟡 Temporaire | Moyenne | Non implémenté |
 
 ## Avantages des Assets Temporaires
 
@@ -103,8 +103,9 @@ Chaque tuile comprend :
 // Obtenir le manager d'assets
 manager := assets.NewManager()
 
-// Tuile avec thème spécifique
-tileImg := manager.GetTileImage("hidden", "forest")
+// Tuile avec thème spécifique (état de l'entité sur la tuile)
+// Les états "hidden", "revealed", "matched" correspondent à TileState de l'entité
+tileImg := manager.GetTileImage(entity.Hidden, "forest")
 
 // Icône de ressource
 berryImg := manager.GetResourceIcon("dreamberry")
@@ -112,6 +113,8 @@ berryImg := manager.GetResourceIcon("dreamberry")
 // Icône de créature
 flyImg := manager.GetCreatureIcon("lumifly")
 ```
+
+Note : Les états visuels (Hidden, Revealed, Matched) à partir de la fusion #18 sont gérés par les entités, pas par les tuiles. Le manager d'assets utilise les états des entités pour afficher le bon visuel.
 
 ## 🎨 Personnalisation
 

--- a/internal/domain/README.md
+++ b/internal/domain/README.md
@@ -59,9 +59,20 @@ func (s *LifecycleSystem) Update(world *World) {
 
 ### Implémentation
 
-- **`entity/`** : Gestion des identités (`ID`, `Manager`)
+- **`entity/`** : Gestion des identités (`ID`, `Type`), des états (`TileState`), et du manager
+  - `TileState` : Hidden, Revealed, Matched, Blocked
+  - `Type` : Resource, Creature, Structure, Artefact, Trap
+  - `Manager` : Stockage et accès rapide aux entités
 - **`component/`** : Stockage et définition des composants (`Store`)
-- **`system.go`** : Systèmes qui traitent les données (`LifecycleSystem`, `CreatureAISystem`)
+- **`system.go`** : Systèmes qui traitent les données
+  - `CreatureAISystem` : Gère les comportements de base des créatures
+  - `CreatureMovementSystem` : Implémente le mouvement avancé avec triggers, navigation, modes
+  - `ResourceLifecycleSystem` : Gère la maturation des ressources
+
+**Note architecture importante** : À partir de la fusion du #18, l'état visuel (`TileState`) appartient à l'entité, pas à la tuile. Cela permet :
+- Une gestion cohérente des états (l'entité contrôle son visibilité)
+- Une séparation claire : le plateau fournit la géométrie, les entités portent la logique
+- Un système plus flexible pour les entités spéciales
 
 ---
 


### PR DESCRIPTION
- Move TileState from tiles to entities in architecture doc
- Document Entity-Component-System (ECS) implementation
- Add CreatureAISystem and CreatureMovementSystem details
- Replace TypeEmptyTile with TypeTrap in domain overview
- Document tile themes (Default, Forest, Cave) for visual assets
- Update asset usage code to reflect entity state management
- Clarify domain layer patterns and architectural decisions