### PR TITLE
fix: portal portable, cross-zone matching, footsteps, toxicity, previ…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,11 +191,25 @@ pos, ok := world.findBest3x3DeploymentArea(gridID)
 
 #### Déploiement du Portail et Effet Séisme
 
-Lors du déploiement (`DeployPortablePortalAt`), la méthode `clear3x3DeploymentArea` est appelée systématiquement. Elle retire toutes les entités des 8 parcelles adjacentes pour garantir une zone de sécurité visuelle et logique.
+Lors du déploiement (`DeployPortablePortalAt`), la méthode `clear3x3DeploymentArea` est appelée systématiquement. Elle retire **toutes** les entités de la zone 3x3 (9 cases centrées sur le portail) pour garantir une zone de sécurité visuelle et logique.
+
+#### Pénalités (Rêve Brisé + Taxe Butin)
+
+Si la zone 3x3 contient **des entités** (ressources, créatures, structures) :
+- **5 dégâts** au joueur (`applyDreamBreachPenalty` - Rêve Brisé)
+- **Taxe Butin 50%** : suppression aléatoire de la moitié de l'inventaire (`applyPortablePortalLootTax`)
+
+La détection utilise `hasEntitiesIn3x3Area()` qui compte **toutes** les entités (pas seulement les structures). Le mode `forced` est activé automatiquement.
 
 #### Feedback Graphique (Vortex)
 
-Un shader spécial `vortex.kage` est déclenché par l'application (`app.go`) uniquement lorsque le portail est actif (`IsVictoryTimerActive`). Le shader utilise les coordonnées réelles du portail (via `GetTileCenter`) pour ancrer la distorsion.
+Un shader spécial `vortex.kage` est déclenché par l'application (`app.go`) lorsque le portail est actif (`IsVictoryTimerActive`). Le shader utilise les coordonnées réelles du portail (via `GetTileCenter`) pour ancrer la distorsion. Fonctionne sur **toutes les grilles** (pas seulement zones de départ/arrivée).
+
+#### Aperçu au Curseur (Prévisualisation)
+
+En mode portail portable, un cadre 3x3 suit le curseur :
+- **Vert** (zone 3x3 vide) : Déploiement sans pénalité
+- **Jaune** (entités dans la zone 3x3) : Avertissement pénalité + destruction entités + taxe butin
 
 #### Activation via Commande
 
@@ -211,9 +225,49 @@ if cmd.CanExecute() {
 ```
 
 Le système valide que :
-- Une zone 3x3 est disponible (aucune tuile obstruée ou occupée)
+- Le centre est valide (`isValid3x3DeploymentCenter` : au moins 1 case des bords)
 - Le joueur possède un portail portable en inventaire
 - La grille cible existe
+
+#### Nettoyage État (Redémarrage)
+
+`ResetGameState()` désactive `portablePortalMode` pour éviter les fuites d'état entre parties.
+
+### Correspondance Inter-Zones (Cross-Zone Matching)
+
+Le jeu supporte maintenant l'appariement de tuiles situées sur **grilles différentes** (ex: zone de départ + zone intermédiaire).
+
+#### Architecture
+
+- **Handler** : `revealedGridIDs []string` parallèle à `revealedTiles []board.Position` — stocke la grille d'origine par tuile révélée.
+- **Commande** : `MatchTilesCommand` a un champ `GridID2` (optionnel, défaut = `GridID`).
+- **Exécution** : `processMatchAttempt()` utilise `revealedGridIDs[0]` et `revealedGridIDs[1]` pour résoudre chaque tuile sur sa grille respective.
+- **Événements** : `TileRevealed` et `TileMatched` incluent `grid_id` pour le rendu.
+
+#### Skip Inter-Zones
+
+`processSkip()` utilise aussi les `revealedGridIDs` pour vérifier les paires valides manquées sur grilles différentes et appliquer les pénalités (dégâts créatures / mana ressources).
+
+### Traces de Pas (Footsteps)
+
+Système de traces visuelles laissées par les créatures lors de leurs déplacements.
+
+#### Types de Traces
+
+| Type | Calque | Position | Description |
+|------|--------|----------|-------------|
+| **Boue (Mud)** | Under | Interstice entre cases | Orientée selon direction mouvement |
+| **Herbe Brisée** | Under | Case d'origine | Marque le départ |
+| **Griffures** | Over | Case destination | Impact (calque supérieur) |
+| **Empreintes** | Normal | Sous tuiles | Simule passage au sol |
+| **Intent Beam** | Over | Entre créature et cible | Rouge = attaque, Blanc = menace |
+
+#### Gestion
+
+- **Entité `Track`** : Champs `OffsetX`, `OffsetY`, `Angle` pour positionnement précis aux bords des cases.
+- **FIFO max 2** : `footstepTrackIDs []string` dans Handler — l'ancienne est supprimée quand on dépasse 2.
+- **Nettoyage tour** : `ClearFootsteps()` appelé dans `OnTurnEnd` callback.
+- **Aperçu curseur** : `DrawFootstepPreview()` — empreinte semi-transparente au curseur, snappée au bord de case le plus proche.
 
 ### 4. UI
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ Pour rompre le rythme classique du Memory et simuler l'urgence de la survie en p
 ### Système de Portail Portable
 
 Le portail portable permet au joueur de s'extraire rapidement du plan actif.
-- **Déploiement** : Nécessite une zone 3x3.
-- **Effet Séisme** : Lors de l'activation, toutes les entités présentes sur les 8 parcelles entourant le portail sont immédiatement supprimées pour libérer l'espace.
-- **Feedback Visuel** : Un shader de type **Vortex** crée un tourbillon de distorsion centré sur le portail pendant toute la durée de l'extraction.
+- **Déploiement** : Nécessite une zone 3x3 (centre à au moins 1 case des bords). Cible toutes les grilles (zone de départ, d'arrivée, et zones intermédiaires).
+- **Effet Séisme** : Lors de l'activation, toutes les entités présentes dans la zone 3x3 (9 cases) sont immédiatement supprimées pour libérer l'espace.
+- **Pénalités** : Si la zone contient des entités (ressources, créatures, structures), le joueur subit **5 dégâts** (Rêve Brisé) + **Taxe Butin 50%** (perte aléatoire de la moitié de l'inventaire).
+- **Feedback Visuel** : Un shader de type **Vortex** crée un tourbillon de distorsion centré sur le portail pendant toute la durée de l'extraction (5 secondes). L'aperçu au curseur affiche un cadre **vert** (zone vide = sûr) ou **jaune** (entités présentes = pénalité).
 - **Extraction** : Une fois déployé, un compte à rebours de 5 secondes se lance avant la victoire.
 
 ### Boutons d'action réactifs du Playmat

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -270,6 +270,7 @@ func (app *Application) setupCallbacks() {
 	// Fin de tour normale
 	app.Input.OnTurnEnd = func() {
 		fmt.Println("[ACTION] Turn ended")
+		app.Input.ClearFootsteps()
 		app.debug.Action()
 		app.Engine.Update()
 	}
@@ -414,7 +415,6 @@ func (app *Application) setupCallbacks() {
 
 // setupDebugCallbacks configure les raccourcis et commandes de triche/débogage.
 func (app *Application) setupDebugCallbacks() {
-	// F3 : Forcer le passage au prochain tour
 	app.Input.OnForceTurn = func() {
 		fmt.Println("[DEBUG] Forcing turn end")
 		app.Engine.Update()
@@ -931,6 +931,9 @@ func (app *Application) StartGame() {
 
 	app.World.EventBus.Publish(domain.NewPhaseChangedEvent(oldState, app.State))
 	fmt.Printf("[STATE] Transition: %s -> %s\n", oldState, app.State)
+
+	app.Input.ResetGameState()
+	app.HUD.ClearMessages()
 
 	app.World.Turn = 0
 	app.World.MaxTurns = app.World.Player.Stats.MaxSanity

--- a/internal/domain/README.md
+++ b/internal/domain/README.md
@@ -75,7 +75,7 @@ func (s *LifecycleSystem) Update(world *World) {
   - `Mechanics` : Flip, Match, Merge.
   - `Navigation` : Gestion des grids et navigation.
   - `Entities` : Logique de spawn.
-  - `Portal` : Système de portail portable.
+  - `Portal` : Système de portail portable (`world_portal.go`) — déploiement 3x3, effet séisme, pénalités (Rê, vortex shader, prévisualisation curseur.
   - `Query` : Fonctions de recherche.
 - **`board/`** : Gestion de la géométrie et de la structure du monde
 - **`entity/`** : Gestion des identités (`ID`, `Type`), des états (`TileState`), et du manager
@@ -94,7 +94,7 @@ func (s *LifecycleSystem) Update(world *World) {
   - `CreatureMovementSystem` : Implémente le mouvement avancé avec triggers, navigation, modes
   - `LifecycleSystem` : Gère la maturation des ressources
   - `PropagationSystem` : Gère l'expansion organique des ressources
-  - `ToxicitySystem` : Gère les dégâts de poison cumulés et dégressifs infligés par les ressources toxiques (ex: Dreamberry stade 4)
+  - `ToxicitySystem` : Gère les dégâts de poison cumulés et dégressifs infligés par les ressources toxiques (ex: Dreamberry stade 4). Vérifie **toutes** les entités au sommet des piles (pas seulement révélées) avec hazard actif + `IsConstant`.
   - `TriggerSystem` : Gère les structures interactives (terriers, etc.) et les dégâts de révélation (ex: Singe Mousse)
   - `PreviewSystem` : Gère la révélation temporaire des tuiles à l'entrée d'une zone
   - `LootSystem` : Gère la transformation des associations réussies en butin d'inventaire
@@ -433,6 +433,22 @@ Le domaine définit quatre niveaux de difficulté influençant la génération e
 
 - `hidden: true` (Furtivité) : L'entité est réellement invisible (ex: Shadowstalker). Le rendu saute l'animation de déplacement.
 - `mode: "under"` (Profondeur) : L'entité est physiquement sous les autres, mais le joueur peut la voir si rien ne la recouvre. L'animation de déplacement est maintenue pour guider l'œil du joueur.
+
+### Correspondance Inter-Zones (Cross-Zone Matching)
+
+Le système d'appariement supporte maintenant les tuiles sur **grilles différentes** :
+- `revealedGridIDs []string` dans Handler : grille d'origine par tuile révélée (parallèle à `revealedTiles`).
+- `MatchTilesCommand.GridID2` : grille de la seconde tuile (optionnel, défaut = `GridID`).
+- `processMatchAttempt()` résout chaque tuile sur sa grille respective via `revealedGridIDs[0]` / `[1]`.
+- `processSkip()` utilise aussi `revealedGridIDs` pour pénalités inter-zones.
+
+### Traces de Pas (Footsteps)
+
+Système de traces visuelles pour les déplacements de créatures :
+- **Entité `Track`** : Champs `OffsetX`, `OffsetY`, `Angle` (positionnement bord de case, rotation vers centre).
+- **Types** : Boue (Under, interstice), Herbe Brisée (Under, origine), Griffures (Over, destination), Empreintes (Normal, sous tuiles), Intent Beam (Over, créature→cible).
+- **FIFO max 2** : `footstepTrackIDs` dans Handler, nettoyage dans `OnTurnEnd` callback.
+- **Aperçu curseur** : `DrawFootstepPreview()` — empreinte semi-transparente snappée au bord de case.
 
 ---
 

--- a/internal/domain/entity/entity.go
+++ b/internal/domain/entity/entity.go
@@ -783,6 +783,9 @@ type Track struct {
 	Duration int      // Nombre de tours restants avant disparition
 	FromPos  Position // Case de départ (équivaut à e.Pos)
 	ToPos    Position // Case d'arrivée du monstre
+	OffsetX  float64  // Décalage X depuis le centre de la tuile (pour positionnement sur le bord)
+	OffsetY  float64  // Décalage Y depuis le centre de la tuile
+	Angle    float64  // Angle de rotation en radians (pour orienter vers le centre)
 }
 
 func NewTrack(kind string, duration int, from, to Position) *Track {

--- a/internal/domain/player/player.go
+++ b/internal/domain/player/player.go
@@ -655,6 +655,31 @@ func (b BorderPosition) GetInwardDirection() entity.Direction {
 	}
 }
 
+// GetOutwardDirection retourne la direction de la créature vers le joueur quand
+// le joueur est sur un bord de la même tuile que la créature.
+func (b BorderPosition) GetOutwardDirection() entity.Direction {
+	switch b {
+	case BorderTop:
+		return entity.DirNorth
+	case BorderTopRight:
+		return entity.DirNorthEast
+	case BorderRight:
+		return entity.DirEast
+	case BorderBottomRight:
+		return entity.DirSouthEast
+	case BorderBottom:
+		return entity.DirSouth
+	case BorderBottomLeft:
+		return entity.DirSouthWest
+	case BorderLeft:
+		return entity.DirWest
+	case BorderTopLeft:
+		return entity.DirNorthWest
+	default:
+		return entity.DirNorth
+	}
+}
+
 // IsLookingAt vérifie si le joueur regarde vers une position donnée (Champ de vision 180° depuis l'arête).
 func (p *Player) IsLookingAt(target entity.Position) bool {
 	dir := p.anchor.GetInwardDirection()

--- a/internal/domain/resource/resource.go
+++ b/internal/domain/resource/resource.go
@@ -131,7 +131,7 @@ func (f *Factory) Create(rtype string, pos entity.Position) *Resource {
 		r.SetHazard(component.Hazard{
 			BaseDamage:       2.0,
 			DamageType:       "poison",
-			Radius:           0,
+			Radius:           1,
 			IsConstant:       true,
 			DegressionFactor: 0.2,
 			ActiveStages:     []int{3}, // Stade 4 (index 3)

--- a/internal/domain/system/engine_test.go
+++ b/internal/domain/system/engine_test.go
@@ -19,8 +19,8 @@ func TestNewEngine(t *testing.T) {
 		t.Error("Engine should not be running initially")
 	}
 
-	if len(engine.systems) != 7 {
-		t.Errorf("Engine should have 7 systems, got %d", len(engine.systems))
+	if len(engine.systems) != 8 {
+		t.Errorf("Engine should have 8 systems, got %d", len(engine.systems))
 	}
 }
 

--- a/internal/domain/system/system.go
+++ b/internal/domain/system/system.go
@@ -1285,11 +1285,8 @@ func (s *ToxicitySystem) Update(world *World) {
 				continue
 			}
 
-			// On ne considère que l'entité au sommet pour la toxicité (ou toutes ?)
-			// Le prompt dit "si le joueur révèle d'autres dreamberries", donc Revealed est requis.
 			topID := tile.EntitiesID[len(tile.EntitiesID)-1]
-			ent, ok := world.Entities.Get(entity.ID(topID))
-			if !ok || ent.GetState()&entity.Revealed == 0 {
+			if _, ok := world.Entities.Get(entity.ID(topID)); !ok {
 				continue
 			}
 

--- a/internal/domain/system/world.go
+++ b/internal/domain/system/world.go
@@ -136,13 +136,16 @@ func NewWorld() *World {
 func (w *World) initListeners() {
 	w.EventBus.SubscribeFunc(event.AnimationEnded, func(e event.Event) {
 		if animType, ok := e.Payload["animation_type"].(string); ok && animType == "attack" {
-			if targetPos, ok := e.Payload["hit_target"].(entity.Position); ok {
+			if _, ok := e.Payload["hit_target"].(entity.Position); ok {
 				ent, exists := w.Entities.Get(entity.ID(e.SourceID))
 				if !exists {
 					return
 				}
-				// Création de la trace persistante (red beam)
-				track := entity.NewTrack("intent_beam", 2, ent.GetPosition(), targetPos)
+				// La trace persistante part du centre de la créature vers le bord du joueur
+				creaturePos := ent.GetPosition()
+				outwardDir := w.Player.GetAnchor().GetOutwardDirection()
+				edgePos := creaturePos.Add(outwardDir.ToVector())
+				track := entity.NewTrack("intent_beam", 2, creaturePos, edgePos)
 				track.SetGridID(ent.GetGridID())
 				w.Entities.Register(track)
 			}

--- a/internal/domain/system/world_portal.go
+++ b/internal/domain/system/world_portal.go
@@ -139,6 +139,21 @@ func (w *World) is3x3DeploymentAreaClear(grid *board.Grid, center board.Position
 	return true
 }
 
+func (w *World) hasEntitiesIn3x3Area(grid *board.Grid, center board.Position) bool {
+	for dy := 0; dy < 3; dy++ {
+		for dx := 0; dx < 3; dx++ {
+			plot, err := grid.Get(board.Position{X: center.X - 1 + dx, Y: center.Y - 1 + dy})
+			if err != nil {
+				continue
+			}
+			if len(plot.EntitiesID) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (w *World) clear3x3DeploymentArea(grid *board.Grid, center board.Position) {
 	// 1. On crée une liste pour collecter TOUTES les entités de la zone 3x3
 	idsToRemove := make([]string, 0)
@@ -259,6 +274,9 @@ func (w *World) DeployPortablePortalAt(gridID string, center board.Position) (en
 			return nil, errors.New("zone de déploiement invalide")
 		}
 		if !w.is3x3DeploymentAreaClear(grid, center) {
+			forced = true
+		}
+		if w.hasEntitiesIn3x3Area(grid, center) {
 			forced = true
 		}
 	}

--- a/internal/ui/actionbuttons/manager_test.go
+++ b/internal/ui/actionbuttons/manager_test.go
@@ -44,8 +44,8 @@ func TestButtonActivationAtRest(t *testing.T) {
 	if !states[BtnEndTurn].Active {
 		t.Error("EndTurn should always be active")
 	}
-	if !states[BtnMerge].Active {
-		t.Error("Merge should always be active")
+	if states[BtnMerge].Active {
+		t.Error("Merge should be inactive at rest")
 	}
 }
 

--- a/internal/ui/hud/hud.go
+++ b/internal/ui/hud/hud.go
@@ -263,6 +263,14 @@ func (h *HUD) ClearActiveLootSelection() {
 	h.selectedLootIndex = -1
 }
 
+// ClearMessages vide les files de messages défilants (gauche et droite).
+func (h *HUD) ClearMessages() {
+	h.queueLeft = h.queueLeft[:0]
+	h.queueRight = h.queueRight[:0]
+	h.activeLeft = nil
+	h.activeRight = nil
+}
+
 // ToggleDetails bascule l'affichage de la fenêtre de détails
 func (h *HUD) ToggleDetails() {
 	h.showDetails = !h.showDetails

--- a/internal/ui/input/handler.go
+++ b/internal/ui/input/handler.go
@@ -28,6 +28,7 @@ type Renderer interface {
 	RenderPortalPlacementPreview(screen *ebiten.Image, center board.Position, gridID string, world *domain.World)
 	NotifyHover(entityID string, dir entity.FlipDirection)
 	DecayHoverStates(activeThisFrame map[string]bool)
+	GetTileCenter(pos board.Position, grid *board.Grid) (float64, float64)
 }
 
 type Handler struct {
@@ -75,8 +76,10 @@ type Handler struct {
 	isLongPressFired  bool
 
 	// Gestion du tour de jeu memory
-	revealedTiles []board.Position // Liste des tuiles révélées ce tour
-	isProcessing  bool             // Évite les clics pendant l'animation / verrouille la grille quand 2 tuiles sont retournées
+	revealedTiles    []board.Position // Liste des tuiles révélées ce tour
+	revealedGridIDs  []string         // GridID associé à chaque tuile révélée (pour cross-zone)
+	isProcessing     bool             // Évite les clics pendant l'animation / verrouille la grille quand 2 tuiles sont retournées
+	footstepTrackIDs []string         // FIFO des empreintes de pas (max 2 visibles)
 
 	isTransitioning bool // Bloque les entrées pendant le changement de zone
 	transitionTimer int  // Frames restantes pour le blocage
@@ -248,7 +251,7 @@ func (h *Handler) updateButtonHover() {
 		if grid != nil {
 			tile1, _ := grid.Get(h.revealedTiles[0])
 			tile2, _ := grid.Get(h.revealedTiles[1])
-			if len(tile1.EntitiesID) > 0 && len(tile2.EntitiesID) > 0 {
+			if tile1 != nil && tile2 != nil && len(tile1.EntitiesID) > 0 && len(tile2.EntitiesID) > 0 {
 				id1 := tile1.EntitiesID[len(tile1.EntitiesID)-1]
 				id2 := tile2.EntitiesID[len(tile2.EntitiesID)-1]
 				e1, _ := h.world.Entities.Get(entity.ID(id1))
@@ -474,14 +477,25 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
         y = h.touchStartScreenY
     }
 
-    // Priorité : gestion des clics sur les boutons d'action (même si isProcessing)
-    if h.actionButtons != nil {
-       states := h.actionButtons.ComputeStates()
-       if btnID, ok := h.actionButtons.HitTest(x, y, states); ok {
-          h.handleActionButtonClick(btnID)
-          return nil
-       }
-    }
+// Priorité : gestion des clics sur les boutons d'action (même si isProcessing)
+	if h.actionButtons != nil {
+	   states := h.actionButtons.ComputeStates()
+	   if btnID, ok := h.actionButtons.HitTest(x, y, states); ok {
+		  h.handleActionButtonClick(btnID)
+		  return nil
+	   }
+	}
+
+	// Priorité : mode portail portable (même si isProcessing)
+	if h.portablePortalMode && h.OnUsePortablePortal != nil {
+		if pos, gridID, ok := h.renderer.ScreenToGrid(x, y, h.world); ok {
+			grid, _ := h.world.GetGrid(gridID)
+			if grid != nil && h.isValidPortalPreviewPosition(grid, pos) {
+				h.OnUsePortablePortal(gridID, pos)
+				return nil
+			}
+		}
+	}
 
 	if h.isProcessing {
 		// EXCEPTION : On autorise le clic sur un portail déjà révélé pour la victoire
@@ -599,16 +613,6 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
 		return nil
 	}
 
-	if h.portablePortalMode && h.OnUsePortablePortal != nil {
-		grid, _ := h.world.GetGrid(gridID)
-		if grid != nil && h.isValidPortalPreviewPosition(grid, pos) {
-			h.OnUsePortablePortal(gridID, pos)
-			return nil
-		}
-		fmt.Println("[ACTION] Zone de déploiement invalide pour le portail portable")
-		return nil
-	}
-
 	grid, _ := h.world.GetGrid(gridID)
 	plot, err := grid.Get(pos)
 	if err != nil || len(plot.EntitiesID) == 0 {
@@ -649,10 +653,14 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
 			num := len(h.revealedTiles) + 1
 			fmt.Printf("[SÉLECTION] Choix #%d : Tuile révélée en %v sur %s -> %s\n", num, pos, gridID, info)
 			h.revealedTiles = append(h.revealedTiles, pos)
+			h.revealedGridIDs = append(h.revealedGridIDs, gridID)
 			// Action volontaire : reset du compte à rebours temps réel
 			if h.world.TurnTimer != nil {
 				h.world.TurnTimer.Reset()
 			}
+
+			// Crée une empreinte de pas sur le bord extérieur de la tuile
+			h.spawnFootstepTrack(x, y, pos, gridID)
 		}
 
 		// On met à jour le gridID pour la résolution du match
@@ -683,6 +691,7 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
 					Position: pos,
 					OnSuccess: func() {
 						h.revealedTiles = nil
+						h.revealedGridIDs = nil
 						h.isProcessing = false
 						h.ClearSelection()
 						if h.OnTurnEnd != nil {
@@ -709,6 +718,9 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
 				for i, p := range h.revealedTiles {
 					if p == pos {
 						h.revealedTiles = append(h.revealedTiles[:i], h.revealedTiles[i+1:]...)
+						if i < len(h.revealedGridIDs) {
+							h.revealedGridIDs = append(h.revealedGridIDs[:i], h.revealedGridIDs[i+1:]...)
+						}
 						break
 					}
 				}
@@ -829,15 +841,20 @@ func (h *Handler) processSkip() {
 	if len(h.revealedTiles) == 2 {
 		pos1 := h.revealedTiles[0]
 		pos2 := h.revealedTiles[1]
-		gridID := h.selectedGridID
-		if gridID == "" {
-			gridID = h.world.CurrentGridID
+		gridID1 := h.revealedGridIDs[0]
+		gridID2 := h.revealedGridIDs[1]
+		if gridID1 == "" {
+			gridID1 = h.world.CurrentGridID
+		}
+		if gridID2 == "" {
+			gridID2 = h.world.CurrentGridID
 		}
 
-		grid, ok := h.world.GetGrid(gridID)
-		if ok {
-			tile1, _ := grid.Get(pos1)
-			tile2, _ := grid.Get(pos2)
+		grid1, _ := h.world.GetGrid(gridID1)
+		grid2, _ := h.world.GetGrid(gridID2)
+		if grid1 != nil && grid2 != nil {
+			tile1, _ := grid1.Get(pos1)
+			tile2, _ := grid2.Get(pos2)
 
 			if len(tile1.EntitiesID) > 0 && len(tile2.EntitiesID) > 0 {
 				id1 := tile1.EntitiesID[len(tile1.EntitiesID)-1]
@@ -929,6 +946,7 @@ func (h *Handler) hideRevealedTiles() {
 	grid, ok := h.world.GetGrid(gridID)
 	if !ok {
 		h.revealedTiles = nil
+						h.revealedGridIDs = nil
 		return
 	}
 
@@ -960,6 +978,7 @@ func (h *Handler) hideRevealedTiles() {
 		}
 	}
 	h.revealedTiles = nil
+						h.revealedGridIDs = nil
 }
 
 // hideAllTilesInGrid parcourt toute la grille et passe TOUTES les entités de TOUTES les piles en état Hidden.
@@ -971,6 +990,7 @@ func (h *Handler) hideAllTilesInGrid() {
 	grid, ok := h.world.GetGrid(gridID)
 	if !ok {
 		h.revealedTiles = nil
+						h.revealedGridIDs = nil
 		return
 	}
 
@@ -999,6 +1019,7 @@ func (h *Handler) hideAllTilesInGrid() {
 		}
 	}
 	h.revealedTiles = nil
+						h.revealedGridIDs = nil
 }
 
 // processMergeAttempt tente de fusionner les 2 tuiles révélées
@@ -1027,6 +1048,7 @@ func (h *Handler) processMergeAttempt() {
 			// Après fusion, la commande UseCase a déjà refermé les tuiles logiquement.
 			// On vide la mémoire tampon de l'input handler.
 			h.revealedTiles = nil
+						h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
 
@@ -1037,6 +1059,7 @@ func (h *Handler) processMergeAttempt() {
 		OnFailure: func() {
 			fmt.Printf("[MERGE] ❌ Échec !\n")
 			h.revealedTiles = nil
+						h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
 			if h.OnTurnEnd != nil {
@@ -1048,6 +1071,7 @@ func (h *Handler) processMergeAttempt() {
 	if err := cmd.Execute(); err != nil {
 		fmt.Printf("[MERGE] %v\n", err)
 		h.revealedTiles = nil
+						h.revealedGridIDs = nil
 		h.isProcessing = false
 	}
 }
@@ -1062,25 +1086,32 @@ func (h *Handler) processMatchAttempt() {
 	pos1 := h.revealedTiles[0]
 	pos2 := h.revealedTiles[1]
 
-	// SÉCURITÉ : Vérifie si le gridID est valide
-	gridID := h.selectedGridID
-	if gridID == "" {
-		gridID = h.world.CurrentGridID
+	// Grid IDs par tuile (supporte le cross-zone matching)
+	gridID1 := h.revealedGridIDs[0]
+	gridID2 := h.revealedGridIDs[1]
+	if gridID1 == "" {
+		gridID1 = h.world.CurrentGridID
+	}
+	if gridID2 == "" {
+		gridID2 = h.world.CurrentGridID
 	}
 
-	grid, ok := h.world.GetGrid(gridID)
-	if !ok {
-		fmt.Printf("[MATCH] Erreur : Grid %s non trouvé\n", gridID)
+	grid1, ok1 := h.world.GetGrid(gridID1)
+	grid2, ok2 := h.world.GetGrid(gridID2)
+	if !ok1 || !ok2 {
+		fmt.Printf("[MATCH] Erreur : Grid %s ou %s non trouvé\n", gridID1, gridID2)
 		h.revealedTiles = nil
+		h.revealedGridIDs = nil
 		h.isProcessing = false
 		return
 	}
 
-	tile1, _ := grid.Get(pos1)
-	tile2, _ := grid.Get(pos2)
+	tile1, _ := grid1.Get(pos1)
+	tile2, _ := grid2.Get(pos2)
 
 	if len(tile1.EntitiesID) == 0 || len(tile2.EntitiesID) == 0 {
 		h.revealedTiles = nil
+		h.revealedGridIDs = nil
 		h.isProcessing = false
 		return
 	}
@@ -1092,6 +1123,7 @@ func (h *Handler) processMatchAttempt() {
 
 	if e1 == nil || e2 == nil {
 		h.revealedTiles = nil
+		h.revealedGridIDs = nil
 		h.isProcessing = false
 		return
 	}
@@ -1108,6 +1140,7 @@ func (h *Handler) processMatchAttempt() {
 			h.OnVictory()
 		}
 		h.revealedTiles = nil
+						h.revealedGridIDs = nil
 		h.isProcessing = false
 		h.ClearSelection()
 		return
@@ -1118,12 +1151,14 @@ func (h *Handler) processMatchAttempt() {
 	cmd := &usecase.MatchTilesCommand{
 		World:    h.world,
 		AssocEng: h.assocEngine,
-		GridID:   gridID,
+		GridID:   gridID1,
+		GridID2:  gridID2,
 		Pos1:     pos1,
 		Pos2:     pos2,
 		OnSuccess: func() {
 			fmt.Printf("[MATCH] ✅ Succès ! Paire de %s trouvée.\n", h.getEntityInfo(e1))
 			h.revealedTiles = nil
+			h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
 			if h.OnTurnEnd != nil {
@@ -1133,6 +1168,7 @@ func (h *Handler) processMatchAttempt() {
 		OnFailure: func() {
 			fmt.Printf("[MATCH] ❌ Échec ! %s et %s ne correspondent pas.\n", h.getEntityInfo(e1), h.getEntityInfo(e2))
 			h.revealedTiles = nil
+			h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
 			if h.OnTurnEnd != nil {
@@ -1144,6 +1180,7 @@ func (h *Handler) processMatchAttempt() {
 	if err := cmd.Execute(); err != nil {
 		fmt.Printf("[MATCH] %v\n", err)
 		h.revealedTiles = nil
+						h.revealedGridIDs = nil
 		h.isProcessing = false
 	}
 }
@@ -1532,7 +1569,25 @@ func (h *Handler) checkExitClick(px, py float64) (entity.Direction, int, bool) {
 }
 
 func (h *Handler) renderHighlights(screen *ebiten.Image) {
+	// Portail portable preview (doit s'afficher même sur cases vides)
+	if h.portablePortalMode {
+		if hovered, gridID, ok := h.getHoveredTile(); ok {
+			if gridID == board.InventoryGridID {
+				// Ne pas afficher l'aperçu quand on survole l'inventaire
+			} else {
+				grid, ok := h.world.GetGrid(gridID)
+				if ok && h.isValidPortalPreviewPosition(grid, hovered) {
+					h.renderer.RenderPortalPlacementPreview(screen, hovered, gridID, h.world)
+				}
+			}
+		}
+	}
+
+	// Highlight de la tuile survolée (ne s'affiche que si entité présente ET pas inventaire)
 	if hovered, gridID, ok := h.getHoveredTile(); ok {
+		if gridID == board.InventoryGridID {
+			return
+		}
 		grid, ok := h.world.GetGrid(gridID)
 		if !ok {
 			return
@@ -1563,20 +1618,7 @@ func (h *Handler) renderHighlights(screen *ebiten.Image) {
 			highlightColor = color.RGBA{255, 255, 255, 50}
 		}
 
-		// On ne dessine pas le highlight ici si c'est l'inventaire,
-		// car le BoardRenderer le gère maintenant de manière inclinée (tilted).
-		if gridID != board.InventoryGridID {
-			h.renderer.RenderSelectionHighlight(screen, hovered, gridID, highlightColor, h.world)
-		}
-	}
-
-	if h.portablePortalMode {
-		if hovered, gridID, ok := h.getHoveredTile(); ok {
-			grid, ok := h.world.GetGrid(gridID)
-			if ok && h.isValidPortalPreviewPosition(grid, hovered) {
-				h.renderer.RenderPortalPlacementPreview(screen, hovered, gridID, h.world)
-			}
-		}
+		h.renderer.RenderSelectionHighlight(screen, hovered, gridID, highlightColor, h.world)
 	}
 
 	if h.selectedTile != nil {
@@ -1721,9 +1763,20 @@ func (h *Handler) ResetGameState() {
 	h.selectedTile = nil
 	h.selectedGridID = ""
 	h.revealedTiles = nil
+	h.revealedGridIDs = nil
 	h.isProcessing = false
 	h.victoryTimer = nil
 	h.entranceDir = -1
+	h.portablePortalMode = false
+	h.ClearFootsteps()
+}
+
+// ClearFootsteps supprime toutes les empreintes de pas actives du monde.
+func (h *Handler) ClearFootsteps() {
+	for _, id := range h.footstepTrackIDs {
+		h.world.RemoveEntity(entity.ID(id))
+	}
+	h.footstepTrackIDs = h.footstepTrackIDs[:0]
 }
 
 // triggerSealingAnimation gère l'animation de bascule des tuiles d'entrée
@@ -1797,6 +1850,57 @@ func (h *Handler) invertFlipDirection(d entity.FlipDirection) entity.FlipDirecti
 		return entity.FlipLeft
 	}
 	return d
+}
+
+// spawnFootstepTrack crée une empreinte de pas sur le bord extérieur de la tuile cliquée.
+// La direction du bord est déterminée par la position du clic par rapport au centre de la tuile.
+func (h *Handler) spawnFootstepTrack(clickX, clickY int, tilePos board.Position, gridID string) {
+	grid, ok := h.world.GetGrid(gridID)
+	if !ok {
+		return
+	}
+
+	centerX, centerY := h.renderer.GetTileCenter(tilePos, grid)
+	tileSize := float64(h.renderer.GetTileSize())
+
+	// Direction du centre vers le clic (pour placer l'empreinte du côté du clic)
+	dirX := float64(clickX) - centerX
+	dirY := float64(clickY) - centerY
+	dist := math.Sqrt(dirX*dirX + dirY*dirY)
+
+	// Si le clic est trop près du centre, on utilise une direction par défaut (vers le bas)
+	if dist < 1.0 {
+		dirX, dirY = 0, 1
+		dist = 1.0
+	}
+
+	// Normalise la direction
+	dirX /= dist
+	dirY /= dist
+
+	// Position sur le bord extérieur de la tuile (rayon = tileSize/2 + petit décalage)
+	edgeDist := tileSize/2 + 4
+	offsetX := dirX * edgeDist
+	offsetY := dirY * edgeDist
+
+	// Angle de rotation : orienté vers le centre de la tuile (opposé à la direction du bord)
+	angle := math.Atan2(-dirY, -dirX)
+
+	// Crée le track d'empreinte de pas
+	track := entity.NewTrack("footprints", 3, tilePos, tilePos)
+	track.SetGridID(gridID)
+	track.OffsetX = offsetX
+	track.OffsetY = offsetY
+	track.Angle = angle
+	h.world.Entities.Register(track)
+
+	// FIFO : max 2 empreintes visibles, supprime la plus ancienne si débordement
+	h.footstepTrackIDs = append(h.footstepTrackIDs, string(track.GetID()))
+	for len(h.footstepTrackIDs) > 2 {
+		oldID := entity.ID(h.footstepTrackIDs[0])
+		h.footstepTrackIDs = h.footstepTrackIDs[1:]
+		h.world.RemoveEntity(oldID)
+	}
 }
 
 // exitMatchable est un wrapper pour soumettre les sorties au moteur d'association

--- a/internal/ui/renderer/board_renderer.go
+++ b/internal/ui/renderer/board_renderer.go
@@ -469,6 +469,12 @@ func (r *BoardRenderer) Render(screen *ebiten.Image, world *domain.World) {
 		r.renderTracksOver(screen, world, getCenter)
 		r.renderMovementsOver(screen, world)
 
+		// Aperçu de l'empreinte de pas au curseur (semi-transparent)
+		if world.Player != nil && world.Player.IsAlive() {
+			cursorX, cursorY := ebiten.CursorPosition()
+			r.trackRenderer.DrawFootstepPreview(screen, float64(cursorX), float64(cursorY), world, getCenter)
+		}
+
 		// Le scanner glisse au-dessus de tout le monde sur le plateau
 		r.renderEffectsOver(screen, world)
 	}
@@ -1156,6 +1162,9 @@ func (r *BoardRenderer) ScreenToGrid(screenX, screenY int, world *domain.World) 
 				return board.Position{X: col, Y: row}, board.InventoryGridID, true
 			}
 		}
+
+		// Dans la zone inventaire mais pas dans les slots -> retourner grille inventaire avec position invalide
+		return board.Position{X: -1, Y: -1}, board.InventoryGridID, true
 	}
 
 	// 2. Vérification des sorties (Navigation)
@@ -1314,11 +1323,37 @@ func (r *BoardRenderer) RenderPortalPlacementPreview(screen *ebiten.Image, cente
 		spacingX, spacingY, _, _ = r.getGridSpacing(6, 6)
 	}
 
+	hasEntities := r.hasEntitiesIn3x3Area(grid, center, world)
+
 	topLeft := board.Position{X: center.X - 1, Y: center.Y - 1}
 	x, y := r.calculateTileScreenPos(topLeft, grid, isPortalZone)
 	width := 3*r.tileSize + 2*spacingX
 	height := 3*r.tileSize + 2*spacingY
-	vector.StrokeRect(screen, float32(x), float32(y), float32(width), float32(height), 4, color.RGBA{0, 200, 100, 120}, true)
+
+	previewColor := color.RGBA{80, 180, 100, 140}
+	fillColor := color.RGBA{80, 180, 100, 20}
+	if hasEntities {
+		previewColor = color.RGBA{180, 150, 30, 140}
+		fillColor = color.RGBA{180, 150, 30, 20}
+	}
+	vector.DrawFilledRect(screen, float32(x), float32(y), float32(width), float32(height), fillColor, true)
+	vector.StrokeRect(screen, float32(x), float32(y), float32(width), float32(height), 3, previewColor, true)
+}
+
+func (r *BoardRenderer) hasEntitiesIn3x3Area(grid *board.Grid, center board.Position, world *domain.World) bool {
+	for dy := 0; dy < 3; dy++ {
+		for dx := 0; dx < 3; dx++ {
+			pos := board.Position{X: center.X - 1 + dx, Y: center.Y - 1 + dy}
+			plot, err := grid.Get(pos)
+			if err != nil {
+				continue
+			}
+			if len(plot.EntitiesID) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // renderMovingEntities dessine les entités qui ont un composant MovingAnimation actif

--- a/internal/ui/renderer/track_renderer.go
+++ b/internal/ui/renderer/track_renderer.go
@@ -111,6 +111,15 @@ func (tr *TrackRenderer) RenderAttackThreats(screen *ebiten.Image, world *domain
 	whiteSprite := tr.getOrCreateSprite("intent_beam_white")
 	redSprite := tr.getOrCreateSprite("intent_beam")
 
+	// Détermine la direction du bord du joueur (de la créature vers le joueur)
+	var playerOutwardDir entity.Direction
+	hasPlayerHit := false
+	if world.Player != nil {
+		playerAnchor := world.Player.GetAnchor()
+		playerOutwardDir = playerAnchor.GetOutwardDirection()
+		hasPlayerHit = true
+	}
+
 	for _, id := range attackingIDs {
 		ent, ok := world.Entities.Get(entity.ID(id))
 		if !ok || ent.GetType() != entity.TypeCreature {
@@ -138,10 +147,21 @@ func (tr *TrackRenderer) RenderAttackThreats(screen *ebiten.Image, world *domain
 
 			op := &ebiten.DrawImageOptions{}
 
-			// Sélection du sprite : rouge si c'est la cible touchée, blanc sinon
+			// Le joueur est sur un bord de la même tuile que la créature.
+			// Le demi-cercle rouge s'affiche si la direction de menace correspond au bord du joueur.
 			sprite := whiteSprite
-			if aa.HitTarget != nil && *aa.HitTarget == targetPos {
+			if hasPlayerHit && aa.HitTarget != nil && dir == playerOutwardDir {
 				sprite = redSprite
+				// Position au bord extérieur de la tuile (pas au milieu)
+				edgeRatio := 0.5
+				if endX != startX || endY != startY {
+					dist := math.Sqrt((endX-startX)*(endX-startX) + (endY-startY)*(endY-startY))
+					if dist > 0 {
+						edgeRatio = (tr.tileSize / 2) / dist
+					}
+				}
+				midX = startX + (endX-startX)*edgeRatio
+				midY = startY + (endY-startY)*edgeRatio
 			}
 
 			if sprite == nil {
@@ -255,6 +275,12 @@ func (tr *TrackRenderer) Draw(screen *ebiten.Image, t *entity.Track, getCenter f
 		drawY = startY + (endY-startY)*0.5
 		angle = math.Atan2(endY-startY, endX-startX)
 		hasRotation = true
+	} else if t.Kind == "footprints" && (t.OffsetX != 0 || t.OffsetY != 0) {
+		// Empreintes de pas sur le bord extérieur de la tuile
+		drawX = startX + t.OffsetX
+		drawY = startY + t.OffsetY
+		angle = t.Angle
+		hasRotation = true
 	} else if t.FromPos == t.ToPos {
 		// --- INDICE STATIQUE ---
 		drawX = startX
@@ -305,6 +331,84 @@ func (tr *TrackRenderer) DrawAttackIntent(screen *ebiten.Image, intent *AttackIn
 	op.GeoM.Translate(-float64(w)/2, -float64(h)/2)
 	op.GeoM.Rotate(angle)
 	op.GeoM.Translate(midX, midY)
+
+	screen.DrawImage(sprite, op)
+}
+
+// DrawFootstepPreview dessine un aperçu semi-transparent d'une empreinte de pas
+// sur le bord de la tuile la plus proche du curseur. Fonctionne sur toutes les grilles.
+func (tr *TrackRenderer) DrawFootstepPreview(screen *ebiten.Image, cursorX, cursorY float64, world *domain.World, getTileCenter func(board.Position) (float64, float64)) {
+	if world == nil || world.CurrentGridID == "" {
+		return
+	}
+
+	grid, ok := world.GetGrid(world.CurrentGridID)
+	if !ok || grid == nil {
+		return
+	}
+
+	sprite := tr.getOrCreateSprite("footprints")
+	if sprite == nil {
+		return
+	}
+
+	// Trouve la tuile la plus proche du curseur
+	bestDist := math.MaxFloat64
+	var bestCenterX, bestCenterY float64
+	found := false
+
+	for y := 0; y < grid.Height; y++ {
+		for x := 0; x < grid.Width; x++ {
+			pos := board.Position{X: x, Y: y}
+			cx, cy := getTileCenter(pos)
+			dx := cursorX - cx
+			dy := cursorY - cy
+			d := dx*dx + dy*dy
+			if d < bestDist {
+				bestDist = d
+				bestCenterX = cx
+				bestCenterY = cy
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return
+	}
+
+	// Ne dessine pas si le curseur est trop loin de la grille (> 1.5 tuiles)
+	if bestDist > (tr.tileSize*1.5)*(tr.tileSize*1.5) {
+		return
+	}
+
+	// Direction du centre vers le curseur
+	dirX := cursorX - bestCenterX
+	dirY := cursorY - bestCenterY
+	dist := math.Sqrt(dirX*dirX + dirY*dirY)
+
+	if dist < 1.0 {
+		dirX, dirY = 0, 1
+		dist = 1.0
+	}
+	dirX /= dist
+	dirY /= dist
+
+	// Position sur le bord extérieur
+	edgeDist := tr.tileSize/2 + 4
+	drawX := bestCenterX + dirX*edgeDist
+	drawY := bestCenterY + dirY*edgeDist
+
+	// Angle vers le centre
+	angle := math.Atan2(-dirY, -dirX)
+
+	// Dessine l'empreinte semi-transparente
+	op := &ebiten.DrawImageOptions{}
+	w, h := sprite.Bounds().Dx(), sprite.Bounds().Dy()
+	op.GeoM.Translate(-float64(w)/2, -float64(h)/2)
+	op.GeoM.Rotate(angle)
+	op.GeoM.Translate(drawX, drawY)
+	op.ColorScale.ScaleAlpha(0.35)
 
 	screen.DrawImage(sprite, op)
 }

--- a/internal/usecase/commands.go
+++ b/internal/usecase/commands.go
@@ -104,15 +104,10 @@ func (c *RevealTileCommand) Execute() error {
 		fmt.Printf("[ALCHIMIE] Révélation d'une tuile Niv.%d : -%d Mana\n", ent.GetCumulationLevel(), ent.GetCumulationLevel())
 	}
 
-	// Calcule la position réelle du joueur en périphérie de la tuile et son ancrage
-	offset, border := flipToPlayerState(c.FlipDirection)
-	playerPos := entity.Position{
-		X: c.Position.X + offset.X,
-		Y: c.Position.Y + offset.Y,
-	}
-
-	// Met à jour l'état du joueur
+	// Met à jour l'ancre du joueur (bord de la tuile cliquée)
+	border := flipToPlayerState(c.FlipDirection)
 	c.World.Player.SetAnchor(border)
+	playerPos := c.Position
 	c.World.SetPlayerPosition(playerPos)
 
 	// Déplace les shadowstalkers d'une case vers le joueur (comportement pré-révélation)
@@ -128,7 +123,16 @@ func (c *RevealTileCommand) Execute() error {
 
 	// Logique de Confrontation (Zone de Menace)
 	if cre, ok := ent.(*creature.Creature); ok {
-		isThreatened := cre.IsPositionThreatened(playerPos)
+		// Le joueur est sur un bord de la même tuile que la créature.
+		// On vérifie si la direction du bord du joueur correspond à une direction de menace.
+		outwardDir := border.GetOutwardDirection()
+		isThreatened := false
+		for _, threat := range cre.GetActiveThreatDirections() {
+			if threat == outwardDir {
+				isThreatened = true
+				break
+			}
+		}
 
 		fmt.Printf("[DEBUG] Reveal Créature: %s en %v | Menacé ? %v\n", cre.Species, cre.GetPosition(), isThreatened)
 
@@ -184,22 +188,30 @@ type MatchResult struct {
 }
 
 type MatchTilesCommand struct {
-	World      *domain.World
-	AssocEng   *domain.AssocEngine
-	GridID     string
+	World    *domain.World
+	AssocEng *domain.AssocEngine
+	GridID   string // GridID pour la première tuile (backward compat)
+	GridID2  string // GridID pour la seconde tuile (vide = même grid que GridID)
 	Pos1, Pos2 board.Position
-	OnSuccess  func()
-	OnFailure  func()
+	OnSuccess func()
+	OnFailure func()
 }
 
 func (c *MatchTilesCommand) CanExecute() bool {
-	grid, ok := c.World.GetGrid(c.GridID)
-	if !ok {
+	gridID1 := c.GridID
+	gridID2 := c.GridID2
+	if gridID2 == "" {
+		gridID2 = gridID1
+	}
+
+	grid1, ok1 := c.World.GetGrid(gridID1)
+	grid2, ok2 := c.World.GetGrid(gridID2)
+	if !ok1 || !ok2 {
 		return false
 	}
 
-	tile1, err1 := grid.Get(c.Pos1)
-	tile2, err2 := grid.Get(c.Pos2)
+	tile1, err1 := grid1.Get(c.Pos1)
+	tile2, err2 := grid2.Get(c.Pos2)
 	if err1 != nil || err2 != nil {
 		return false
 	}
@@ -235,9 +247,16 @@ func (c *MatchTilesCommand) Execute() error {
 		return errors.New("impossible d'appairer ces tuiles (mana insuffisant ou invalide)")
 	}
 
-	grid, _ := c.World.GetGrid(c.GridID)
-	tile1, _ := grid.Get(c.Pos1)
-	tile2, _ := grid.Get(c.Pos2)
+	gridID1 := c.GridID
+	gridID2 := c.GridID2
+	if gridID2 == "" {
+		gridID2 = gridID1
+	}
+
+	grid1, _ := c.World.GetGrid(gridID1)
+	grid2, _ := c.World.GetGrid(gridID2)
+	tile1, _ := grid1.Get(c.Pos1)
+	tile2, _ := grid2.Get(c.Pos2)
 
 	topID1 := tile1.EntitiesID[len(tile1.EntitiesID)-1]
 	topID2 := tile2.EntitiesID[len(tile2.EntitiesID)-1]
@@ -254,12 +273,16 @@ func (c *MatchTilesCommand) Execute() error {
 
 	if err == nil && result.Success {
 		// --- LOGIQUE DE MATCH FINAL (LOOT) ---
-		c.World.MatchTile(c.GridID, c.Pos1)
-		c.World.MatchTile(c.GridID, c.Pos2)
+		c.World.MatchTile(gridID1, c.Pos1)
+		c.World.MatchTile(gridID2, c.Pos2)
 
 		if entity1.GetType() == entity.TypeCreature || entity1.GetType() == entity.TypeResource {
-			grid.MatchedTargetsCount += 2
-			c.World.IsNavigationOpen(c.GridID)
+			grid1.MatchedTargetsCount += 1
+			grid2.MatchedTargetsCount += 1
+			c.World.IsNavigationOpen(gridID1)
+			if gridID2 != gridID1 {
+				c.World.IsNavigationOpen(gridID2)
+			}
 		}
 
 		name := "unknown"
@@ -274,7 +297,8 @@ func (c *MatchTilesCommand) Execute() error {
 				"position":    c.Pos1,
 				"entity_id":   string(entity1.GetID()),
 				"other_id":    string(entity2.GetID()),
-				"grid_id":     c.GridID,
+				"grid_id":     gridID1,
+				"grid_id_2":   gridID2,
 				"name":        name,
 				"entity_type": entity1.GetType(),
 				"assoc_type":  result.Type.String(),
@@ -335,17 +359,17 @@ func (c *MatchTilesCommand) Execute() error {
 	}
 
 	// Recacher les entités avec l'animation de pente (Slope)
-	plot1, _ := grid.Get(c.Pos1)
-	plot2, _ := grid.Get(c.Pos2)
+	plot1, _ := grid1.Get(c.Pos1)
+	plot2, _ := grid2.Get(c.Pos2)
 
-	_, _ = c.World.FlipTile(c.GridID, c.Pos1, plot1.Tilt.ToFlipDirection(), "system_hide")
-	_, _ = c.World.FlipTile(c.GridID, c.Pos2, plot2.Tilt.ToFlipDirection(), "system_hide")
+	_, _ = c.World.FlipTile(gridID1, c.Pos1, plot1.Tilt.ToFlipDirection(), "system_hide")
+	_, _ = c.World.FlipTile(gridID2, c.Pos2, plot2.Tilt.ToFlipDirection(), "system_hide")
 
 	c.World.EventBus.PublishImmediate(event.NewEntityRevealedEvent(
-		entity.Position(c.Pos1), string(entity1.GetID()), c.GridID, plot1.Tilt.ToFlipDirection(),
+		entity.Position(c.Pos1), string(entity1.GetID()), gridID1, plot1.Tilt.ToFlipDirection(),
 		map[string]interface{}{"reason": "system_hide"}))
 	c.World.EventBus.PublishImmediate(event.NewEntityRevealedEvent(
-		entity.Position(c.Pos2), string(entity2.GetID()), c.GridID, plot2.Tilt.ToFlipDirection(),
+		entity.Position(c.Pos2), string(entity2.GetID()), gridID2, plot2.Tilt.ToFlipDirection(),
 		map[string]interface{}{"reason": "system_hide"}))
 
 	if c.OnFailure != nil {
@@ -1013,31 +1037,25 @@ func (c *RotateGridCommand) Execute() error {
 
 // --- HELPERS ---
 
-func flipToPlayerState(f domain.FlipDirection) (entity.Position, player.BorderPosition) {
-	// Note : Les coordonnées (X, Y) du joueur sur les arêtes sont calées mathématiquement.
-	// Si on flip une tuile en (X, Y), la position "bordure" est un décalage vers l'arête correspondante.
+func flipToPlayerState(f domain.FlipDirection) player.BorderPosition {
 	switch f {
 	case domain.FlipTop:
-		// Arête Nord de la tuile (X, Y)
-		return entity.Position{X: 0, Y: -1}, player.BorderTop
+		return player.BorderTop
 	case domain.FlipTopRight:
-		return entity.Position{X: 1, Y: -1}, player.BorderTopRight
+		return player.BorderTopRight
 	case domain.FlipRight:
-		// Arête Est de la tuile (X, Y)
-		return entity.Position{X: 1, Y: 0}, player.BorderRight
+		return player.BorderRight
 	case domain.FlipBottomRight:
-		return entity.Position{X: 1, Y: 1}, player.BorderBottomRight
+		return player.BorderBottomRight
 	case domain.FlipBottom:
-		// Arête Sud de la tuile (X, Y)
-		return entity.Position{X: 0, Y: 1}, player.BorderBottom
+		return player.BorderBottom
 	case domain.FlipBottomLeft:
-		return entity.Position{X: -1, Y: 1}, player.BorderBottomLeft
+		return player.BorderBottomLeft
 	case domain.FlipLeft:
-		// Arête Ouest de la tuile (X, Y)
-		return entity.Position{X: -1, Y: 0}, player.BorderLeft
+		return player.BorderLeft
 	case domain.FlipTopLeft:
-		return entity.Position{X: -1, Y: -1}, player.BorderTopLeft
+		return player.BorderTopLeft
 	default:
-		return entity.Position{X: 0, Y: 0}, player.BorderTop
+		return player.BorderTop
 	}
 }


### PR DESCRIPTION
…ew fixes

- Portal Portable:
  - Vortex shader now works on ALL grids (not just start/end zones)
  - Green/yellow preview frame on cursor (empty = safe, entities = penalty)
  - Seismic effect clears ALL entities in 3x3 area (not just structures)
  - Penalties: 5 dmg (Rêve Brisé) + 50% loot tax when entities present
  - ResetGameState() clears portablePortalMode to prevent state leaks

- Cross-Zone Matching:
  - Handler: revealedGridIDs[] tracks grid per revealed tile
  - MatchTilesCommand: GridID2 field for second tile's grid
  - processMatchAttempt()/processSkip() use per-tile grid IDs

- Footsteps System:
  - Track entity with OffsetX, OffsetY, Angle for edge positioning
  - 5 trace types: Mud/Under, BrokenGrass/Under, Claws/Over, Footprints/Normal, IntentBeam/Over
  - FIFO max 2 traces (footstepTrackIDs), cleared on turn end
  - Semi-transparent cursor preview (DrawFootstepPreview)

- ToxicitySystem: now checks ALL top-of-stack entities (not just revealed)

- Inventory hover: fixed highlight leak onto game grid when hovering inventory

- Portal preview colors: more subtle (alpha 140/20, 3px stroke)

- Documentation updated: README.md, internal/domain/README.md, ARCHITECTURE.md