### PR TITLE
fix: neutralise les mécaniques positionnelles quand le joueur ne se d…

### DIFF
--- a/internal/domain/creature/creature.go
+++ b/internal/domain/creature/creature.go
@@ -121,6 +121,7 @@ type AI interface {
 // WorldState interface pour que l'IA puisse observer le monde
 type WorldState interface {
 	GetPlayerPosition() entity.Position
+	IsPlayerOnBoard() bool
 	GetNearbyCreatures(pos entity.Position, radius int) []*Creature
 	GetResources(pos entity.Position, radius int) []string
 	IsValidMove(pos entity.Position) bool
@@ -186,6 +187,9 @@ func (ai *SimpleAI) Decide(c *Creature, world WorldState) Action {
 		return Action{Type: "idle"}
 
 	case "fleeing":
+		if !world.IsPlayerOnBoard() {
+			return Action{Type: "idle"}
+		}
 		playerPos := world.GetPlayerPosition()
 		creaturePos := c.GetPosition()
 
@@ -206,6 +210,9 @@ func (ai *SimpleAI) Decide(c *Creature, world WorldState) Action {
 		return Action{Type: "move", Direction: bestMove}
 
 	case "hunting":
+		if !world.IsPlayerOnBoard() {
+			return Action{Type: "idle"}
+		}
 		playerPos := world.GetPlayerPosition()
 		creaturePos := c.GetPosition()
 

--- a/internal/domain/creature/creature_test.go
+++ b/internal/domain/creature/creature_test.go
@@ -82,6 +82,8 @@ func (m *mockWorldState) GetNearbyCreatures(pos entity.Position, radius int) []*
 	return nil
 }
 
+func (m *mockWorldState) IsPlayerOnBoard() bool { return true }
+
 func (m *mockWorldState) GetEmptyPlots() []entity.Position {
 	return nil
 }

--- a/internal/domain/creature/movement_test.go
+++ b/internal/domain/creature/movement_test.go
@@ -101,6 +101,7 @@ func TestCreatureOrientationRespectsTransformation(t *testing.T) {
 type mockWorldQuery struct{}
 
 func (m *mockWorldQuery) GetPlayerPosition() entity.Position                             { return entity.Position{} }
+func (m *mockWorldQuery) IsPlayerOnBoard() bool                                         { return true }
 func (m *mockWorldQuery) GetNearbyCreatures(pos entity.Position, radius int) []*Creature { return nil }
 func (m *mockWorldQuery) GetResources(pos entity.Position, radius int) []string          { return nil }
 func (m *mockWorldQuery) IsValidMove(pos entity.Position) bool                           { return true }

--- a/internal/domain/system/aggression_system.go
+++ b/internal/domain/system/aggression_system.go
@@ -278,6 +278,10 @@ func (s *AggressionSystem) onAnimationEnded(e event.Event) {
 }
 
 func (s *AggressionSystem) triggerExceededAttack(c *creature.Creature) {
+	if !s.world.IsPlayerOnBoard() {
+		return
+	}
+
 	fmt.Printf("[AGGRESSION] %s est excédée ! ATTAQUE IMMÉDIATE.\n", c.Species)
 
 	// --- Logique de Confrontation Périphérique ---

--- a/internal/domain/system/system.go
+++ b/internal/domain/system/system.go
@@ -1015,6 +1015,10 @@ func (wa *worldAdapter) GetPlayerPosition() entity.Position {
 	return wa.world.playerPosition
 }
 
+func (wa *worldAdapter) IsPlayerOnBoard() bool {
+	return wa.world.IsPlayerOnBoard()
+}
+
 func (wa *worldAdapter) GetNearbyCreatures(pos entity.Position, radius int) []*creature.Creature {
 	var result []*creature.Creature
 	creatures := wa.world.Entities.GetByType(entity.TypeCreature)
@@ -1098,6 +1102,9 @@ func (wa *worldAdapter) FindNearestTarget(from entity.Position, targetType creat
 	case creature.TargetPlayer:
 		// Seule l'attraction/répulsion du joueur sur sa propre grille est possible
 		if wa.world.CurrentGridID != wa.grid.ID {
+			return nil
+		}
+		if !wa.world.IsPlayerOnBoard() {
 			return nil
 		}
 		pos := wa.world.playerPosition
@@ -1327,6 +1334,10 @@ func (s *ToxicitySystem) Priority() int { return 6 }
 
 func (s *ToxicitySystem) Update(world *World) {
 	if world.Player == nil {
+		return
+	}
+
+	if !world.IsPlayerOnBoard() {
 		return
 	}
 

--- a/internal/domain/system/world.go
+++ b/internal/domain/system/world.go
@@ -46,6 +46,7 @@ type World struct {
 
 	// Player
 	playerPosition entity.Position
+	playerOnBoard  bool // true si le joueur est physiquement présent sur le plateau
 
 	// Turn state tracking
 	tilesFlippedThisTurn []board.Position // Tracks tiles flipped in current turn (max 2)
@@ -94,6 +95,7 @@ func NewWorld() *World {
 		Hub:                  meta.NewHub(),
 		Player:               p,
 		playerPosition:       entity.Position{X: 0, Y: 0},
+		playerOnBoard:        true,
 		tilesFlippedThisTurn: make([]board.Position, 0),
 		lastTurnNumber:       0,
 		TurnTimer:            NewTurnTimer(meta.GetSettings(meta.LevelNormal).TurnTimerDuration),

--- a/internal/domain/system/world_navigation.go
+++ b/internal/domain/system/world_navigation.go
@@ -484,7 +484,7 @@ func (w *World) RotateGrid(gridID string) error {
 	}
 
 	// 4. Mettre à jour la position du joueur si il est sur cette grille
-	if w.CurrentGridID == gridID {
+	if w.CurrentGridID == gridID && w.playerOnBoard {
 		oldPlayerPos := w.playerPosition
 		w.playerPosition = board.Position{
 			X: oldHeight - 1 - oldPlayerPos.Y,

--- a/internal/domain/system/world_query.go
+++ b/internal/domain/system/world_query.go
@@ -47,6 +47,16 @@ func (w *World) GetPlayerPosition() entity.Position {
 	return w.playerPosition
 }
 
+// SetPlayerOnBoard définit si le joueur est physiquement présent sur le plateau
+func (w *World) SetPlayerOnBoard(on bool) {
+	w.playerOnBoard = on
+}
+
+// IsPlayerOnBoard indique si le joueur est présent sur le plateau
+func (w *World) IsPlayerOnBoard() bool {
+	return w.playerOnBoard
+}
+
 // MoveSpeciesOneStepTowards est un wrapper pratique pour appeler le CreatureMovementSystem
 // depuis d'autres couches (usecases, UI) sans exposer directement le movementSystem.
 func (w *World) MoveSpeciesOneStepTowards(species string, target entity.Position) {

--- a/internal/ui/input/handler.go
+++ b/internal/ui/input/handler.go
@@ -696,18 +696,16 @@ func (h *Handler) executePrimaryActionAt(x, y int) error {
 					GridID:   gridID,
 					Position: pos,
 					OnSuccess: func() {
-						h.revealedTiles = nil
-						h.revealedGridIDs = nil
-						h.isProcessing = false
-						h.ClearSelection()
-						if h.OnTurnEnd != nil {
-							h.OnTurnEnd()
-						}
-					},
-				}
-				if err := cmd.Execute(); err != nil {
-					fmt.Printf("[ACTION] Erreur défausse : %v\n", err)
-				}
+					h.revealedTiles = nil
+					h.revealedGridIDs = nil
+					h.isProcessing = false
+					h.ClearSelection()
+					h.endTurn()
+				},
+			}
+			if err := cmd.Execute(); err != nil {
+				fmt.Printf("[ACTION] Erreur défausse : %v\n", err)
+			}
 				return nil
 			}
 
@@ -835,14 +833,20 @@ func (h *Handler) handleActionButtonClick(btnID actionbuttons.ButtonID) {
 	}
 }
 
+// endTurn synchronise l'état du joueur sur le plateau puis termine le tour.
+func (h *Handler) endTurn() {
+	h.world.SetPlayerOnBoard(h.isMovedThisTurn)
+	if h.OnTurnEnd != nil {
+		h.OnTurnEnd()
+	}
+	h.isMovedThisTurn = false
+}
+
 // processSkip recache les tuiles révélées et termine le tour.
 func (h *Handler) processSkip() {
-	// Si rien à cacher, on se contente d'appeler OnTurnEnd (le reset du timer est géré ailleurs)
+	// Si rien à cacher, on se contente d'appeler endTurn (le reset du timer est géré ailleurs)
 	if len(h.revealedTiles) == 0 {
-		if h.OnTurnEnd != nil {
-			h.OnTurnEnd()
-		}
-		h.isMovedThisTurn = false
+		h.endTurn()
 		return
 	}
 
@@ -941,10 +945,7 @@ func (h *Handler) processSkip() {
 	h.hideAllTilesInGrid()
 	h.ClearSelection()
 
-	if h.OnTurnEnd != nil {
-		h.OnTurnEnd()
-	}
-	h.isMovedThisTurn = false
+	h.endTurn()
 }
 
 // hideRevealedTiles remet l'état Hidden sur toutes les tuiles de revealedTiles (toute la pile).
@@ -1057,9 +1058,7 @@ func (h *Handler) processMergeAttempt() {
 			h.isProcessing = false
 			h.ClearSelection()
 
-			if h.OnTurnEnd != nil {
-				h.OnTurnEnd()
-			}
+			h.endTurn()
 		},
 		OnFailure: func() {
 			fmt.Printf("[MERGE] ❌ Échec !\n")
@@ -1067,9 +1066,7 @@ func (h *Handler) processMergeAttempt() {
 						h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
-			if h.OnTurnEnd != nil {
-				h.OnTurnEnd()
-			}
+			h.endTurn()
 		},
 	}
 
@@ -1166,9 +1163,7 @@ func (h *Handler) processMatchAttempt() {
 			h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
-			if h.OnTurnEnd != nil {
-				h.OnTurnEnd()
-			}
+			h.endTurn()
 		},
 		OnFailure: func() {
 			fmt.Printf("[MATCH] ❌ Échec ! %s et %s ne correspondent pas.\n", h.getEntityInfo(e1), h.getEntityInfo(e2))
@@ -1176,9 +1171,7 @@ func (h *Handler) processMatchAttempt() {
 			h.revealedGridIDs = nil
 			h.isProcessing = false
 			h.ClearSelection()
-			if h.OnTurnEnd != nil {
-				h.OnTurnEnd()
-			}
+			h.endTurn()
 		},
 	}
 
@@ -1487,16 +1480,12 @@ func (h *Handler) tryMatchSelected() {
 				OnSuccess: func() {
 					fmt.Println("[MATCH] ✅ Succès !")
 					h.ClearSelection()
-					if h.OnTurnEnd != nil {
-						h.OnTurnEnd()
-					}
+					h.endTurn()
 				},
 				OnFailure: func() {
 					fmt.Println("[MATCH] ❌ Échec !")
 					h.ClearSelection()
-					if h.OnTurnEnd != nil {
-						h.OnTurnEnd()
-					}
+					h.endTurn()
 				},
 			}
 
@@ -1774,10 +1763,7 @@ func (h *Handler) ResetTimerSkip() {
 	}
 	h.isProcessing = false
 	h.ClearSelection()
-	if h.OnTurnEnd != nil {
-		h.OnTurnEnd()
-	}
-	h.isMovedThisTurn = false
+	h.endTurn()
 }
 
 // ResetGameState réinitialise l'état du jeu (pour retour au menu)
@@ -1793,6 +1779,7 @@ func (h *Handler) ResetGameState() {
 	h.isMovedThisTurn = false
 	h.ClearFootsteps()
 	if h.world != nil {
+		h.world.SetPlayerOnBoard(false)
 		h.world.ActiveAnimationCount = 0
 	}
 }
@@ -1940,6 +1927,9 @@ func (h *Handler) spawnFootstepTrack(clickX, clickY int, tilePos board.Position,
 // spawnFootstepAtArrival crée une empreinte de pas sur le bord de la tuile d'arrivée
 // quand le joueur entre dans une nouvelle zone.
 func (h *Handler) spawnFootstepAtArrival(arrivalDir entity.Direction) {
+	if !h.world.IsPlayerOnBoard() {
+		return
+	}
 	pos := h.world.GetPlayerPosition()
 	grid, ok := h.world.GetGrid(h.world.CurrentGridID)
 	if !ok || grid == nil {

--- a/internal/usecase/commands.go
+++ b/internal/usecase/commands.go
@@ -110,7 +110,7 @@ func (c *RevealTileCommand) Execute() error {
 	c.World.SetPlayerPosition(playerPos)
 
 	// Déplace les shadowstalkers d'une case vers le joueur (comportement pré-révélation)
-	if c.World != nil {
+	if c.World != nil && c.World.IsPlayerOnBoard() {
 		c.World.MoveSpeciesOneStepTowards("shadowstalker", c.World.GetPlayerPosition())
 	}
 


### PR DESCRIPTION
…éplace pas

- Ajoute playerOnBoard dans World, synchronisé avec isMovedThisTurn
- Guard ToxicitySystem : pas de dégâts poison quand le joueur absent
- Guard AggressionSystem : pas d'attaque quand le joueur absent
- Guard creature AI (hunting/fleeing) : idle quand le joueur absent
- Guard FindNearestTarget : retourne nil quand le joueur absent
- Guard shadowstalker movement : ignoré quand le joueur absent
- Guard grid rotation : pas de transformation de position si absent
- Guard spawnFootstepAtArrival : ignoré si le joueur absent
- Méthode endTurn() dans Handler synchronise isMovedThisTurn → playerOnBoard
- Ajoute IsPlayerOnBoard() à l'interface WorldState