### PR TITLE
feat: cave shader avec lights HUD, corrections amnésie et optimisatio…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -378,7 +378,7 @@ Séparation des responsabilités :
   - **Système de Messages Défilants**: Gère deux zones de notification indépendantes (**Gauche** et **Droite**) avec des files d'attente prioritaires. Chaque message défile de droite à gauche deux fois avant de disparaître.
     - **Zone Gauche**: Affiche les messages narratifs et les effets d'utilisation d'objets (ex: "Vous êtes déboussolé.", "Vous toussez du sang.", "La mémoire revient...").
     - **Zone Droite**: Affiche les feedbacks de gameplay immédiats (ex: "CONFRONTATION ! -10 HP", "TOXICITÉ ! -X HP", "AMNÉSIE ! X tours.", "MATCH INVALIDE !").
-- **EffectRenderer** (`renderer/effect_renderer.go`) : Gère les shaders globaux (Wave, Heat, Bubble, Blur, Lumifly) avec un système de ping-pong buffers. L'intensité des effets est couplée dynamiquement à la **Santé Mentale** du joueur. Peut être forcé via la **Console de Debug**.
+- **EffectRenderer** (`renderer/effect_renderer.go`) : Gère les shaders globaux (Wave, Heat, Bubble, Blur, Lumifly, Cave) avec un système de ping-pong buffers. L'intensité des effets est couplée dynamiquement à la **Santé Mentale** du joueur. Peut être forcé via la **Console de Debug**.
   - **Lumifly Shader** (`renderer/shader/lumifly.kage`) : Onde lumineuse dorée circulaire avec silhouettes d'entités. Centre calculé via `calculateTileScreenPos` pour un alignement parfait avec les tuiles. Rayon basé sur la diagonale d'une case (`√2`).
   - **Silhouettes sur le Dos** : Chaque tuile affiche la silhouette de son entité sur le dos (alpha variable), utilisée par le shader Lumifly pour les effets de révélation. Les UVs du dos sont transformés par la D4 avec miroir horizontal.
 
@@ -387,6 +387,13 @@ Séparation des responsabilités :
   - **Frame Buffer** (`quakeFrameBuffer`) : 990×990, reçoit la sortie du shader, puis `SubImage` centre 700×700 affiché à `(PlaymatX, PlaymatY)`.
   - **Uniforms** : `RotationAngle` (Pi/2 ou -Pi/2), `Clockwise` (bool), `GhostSize` [990,990], `Resolution` [990,990].
   - **Rendu** : `RenderQuakeOverlay` appelé après `ProcessGlobalEffects` pour le plus haut z-index.
+
+- **Cave Shader** (`renderer/shader/cave.kage`) : Effet d'ambiance oppressive pour le biome grotte. Couplé à la **Santé Mentale** du joueur via le paramètre `Intensity` (0.0 = sane, 1.0 = folie totale).
+  - **Obscurité de fond** : Assombrit uniformément l'écran (55% à sanity满 → 98% à sanity 0). La torche centrale crée un cercle de lumière proportionnel à la folie.
+  - **Torche centre** : Rayon de 175px (sanity满) → 13px (sanity 0). Force de 35% (sanity满) → 95% (sanity 0). Vacillement procédural (`hash12`) avec amplitude croissante.
+  - **Lights HUD** : Cercles de lumière fixes sur les panneaux HUD (Portrait, Inventaire, Jauges, Minimap). Le rayon est contraint aux dimensions du panneau (`smoothstep(r*edge, r, dist)`). L'ombre interne rétrécit avec l'intensité (0.85 → 0.15), étendant la zone éclairée du centre vers les bords.
+  - **Uniforms** : `Time`, `Intensity`, `Resolution`, `HudLights [16]float` (4 × `[cx, cy, radius, _]`).
+  - **Application** : Appliqué dans `ProcessGlobalEffects` via `applyCaveShader()`, après les biomes (wave/heat/rain) et avant les effets créatures.
 
 - **DebugWindow** (`ui/debug/window.go`) : Console de débogage interactive (F12) permettant de modifier les statistiques, la difficulté, et de filtrer les entités spawnables. Contrôle la vitesse de défilement des messages HUD (`MessageSpeed` via `+`/`-`).
 

--- a/internal/domain/component/component.go
+++ b/internal/domain/component/component.go
@@ -13,12 +13,14 @@ type Component interface {
 
 // Store stocke les composants par entité
 type Store struct {
-	components map[string]map[string]Component // entityID -> componentType -> Component
+	components  map[string]map[string]Component // entityID -> componentType -> Component
+	byComponent map[string]map[string]bool      // componentType -> entityID -> present
 }
 
 func NewStore() *Store {
 	return &Store{
-		components: make(map[string]map[string]Component),
+		components:  make(map[string]map[string]Component),
+		byComponent: make(map[string]map[string]bool),
 	}
 }
 
@@ -27,6 +29,10 @@ func (s *Store) Add(entityID string, c Component) {
 		s.components[entityID] = make(map[string]Component)
 	}
 	s.components[entityID][c.Type()] = c
+	if s.byComponent[c.Type()] == nil {
+		s.byComponent[c.Type()] = make(map[string]bool)
+	}
+	s.byComponent[c.Type()][entityID] = true
 }
 
 func (s *Store) Get(entityID string, componentType string) (Component, bool) {
@@ -40,6 +46,9 @@ func (s *Store) Get(entityID string, componentType string) (Component, bool) {
 func (s *Store) Remove(entityID string, componentType string) {
 	if s.components[entityID] != nil {
 		delete(s.components[entityID], componentType)
+	}
+	if s.byComponent[componentType] != nil {
+		delete(s.byComponent[componentType], entityID)
 	}
 }
 
@@ -60,17 +69,23 @@ func (s *Store) GetAll(entityID string) []Component {
 }
 
 func (s *Store) QueryByComponent(componentType string) []string {
-	var result []string
-	for entityID, comps := range s.components {
-		if _, ok := comps[componentType]; ok {
-			result = append(result, entityID)
-		}
+	ids := s.byComponent[componentType]
+	result := make([]string, 0, len(ids))
+	for entityID := range ids {
+		result = append(result, entityID)
 	}
 	return result
 }
 
 func (s *Store) RemoveEntity(entityID string) {
-	delete(s.components, entityID)
+	if comps, ok := s.components[entityID]; ok {
+		for compType := range comps {
+			if s.byComponent[compType] != nil {
+				delete(s.byComponent[compType], entityID)
+			}
+		}
+		delete(s.components, entityID)
+	}
 }
 
 // --- Composants concrets ---

--- a/internal/domain/entity/entity.go
+++ b/internal/domain/entity/entity.go
@@ -675,6 +675,9 @@ type Manager struct {
 	byPos       map[Position]ID
 	cacheByType map[Type][]Entity
 	dirtyTypes  map[Type]bool
+	// Cache pour GetAllActive()
+	activeCache []Entity
+	dirtyActive bool
 }
 
 func NewManager() *Manager {
@@ -700,6 +703,7 @@ func (m *Manager) Register(e Entity) {
 
 	// Invalide le cache pour ce type
 	m.dirtyTypes[e.GetType()] = true
+	m.dirtyActive = true
 }
 
 func (m *Manager) Remove(id ID) {
@@ -713,6 +717,7 @@ func (m *Manager) Remove(id ID) {
 
 	// Invalide le cache pour ce type
 	m.dirtyTypes[e.GetType()] = true
+	m.dirtyActive = true
 }
 
 func (m *Manager) Get(id ID) (Entity, bool) {
@@ -762,12 +767,17 @@ func (m *Manager) GetByType(t Type) []Entity {
 }
 
 func (m *Manager) GetAllActive() []Entity {
+	if !m.dirtyActive && m.activeCache != nil {
+		return m.activeCache
+	}
 	result := make([]Entity, 0)
 	for _, e := range m.entities {
 		if e.IsActive() {
 			result = append(result, e)
 		}
 	}
+	m.activeCache = result
+	m.dirtyActive = false
 	return result
 }
 

--- a/internal/domain/system/aggression_system.go
+++ b/internal/domain/system/aggression_system.go
@@ -136,15 +136,11 @@ func (s *AggressionSystem) updateAggressionFactors(c *creature.Creature) {
 	}
 	c.Behavior.AggressionFactors["inventory"] = inventoryAgg
 
-	// 2. Facteur Grille (Species Anger)
+	// 2. Facteur Grille (Species Anger) — O(1) via compteur maintenu par le World
 	speciesAnger := 0
-	revealedSameSpecies := 0
-	for _, e := range s.world.Entities.GetAllActive() {
-		if other, ok := e.(*creature.Creature); ok && other.Species == c.Species {
-			if other.GetID() != c.GetID() && other.GetState()&entity.Revealed != 0 {
-				revealedSameSpecies++
-			}
-		}
+	revealedSameSpecies := s.world.RevealedBySpecies[c.Species]
+	if c.GetState()&entity.Revealed != 0 {
+		revealedSameSpecies-- // Exclure soi-même
 	}
 	if revealedSameSpecies > 0 {
 		speciesAnger = revealedSameSpecies * 20

--- a/internal/domain/system/aggression_test.go
+++ b/internal/domain/system/aggression_test.go
@@ -83,6 +83,7 @@ func TestAggressionSystem_Factors(t *testing.T) {
 	// On ajoute une autre créature de la même espèce et on la révèle
 	c2, _ := w.SpawnCreature("test", "lumifly", entity.Position{X: 0, Y: 0})
 	c2.SetState(entity.Revealed)
+	w.RevealedBySpecies[c2.Species]++
 
 	sys.Update(w)
 

--- a/internal/domain/system/engine.go
+++ b/internal/domain/system/engine.go
@@ -21,6 +21,8 @@ type Engine struct {
 	previewSystem  *PreviewSystem          // Référence pour les événements
 	lootSystem     *LootSystem
 	comboSystem    *ComboSystem
+	// Cache: true si la grille courante contient au moins une entité matchable (défaut: true = non vide)
+	hasMatchableEntities bool
 }
 
 // NewEngine initialise le moteur de jeu avec ses systèmes
@@ -31,7 +33,8 @@ func NewEngine(world *World) *Engine {
 	comboSys := NewComboSystem(world)
 
 	e := &Engine{
-		world: world,
+		world:                world,
+		hasMatchableEntities: true, // Par défaut non vide (comportement original)
 		systems: []System{
 			&LifecycleSystem{},
 			&PropagationSystem{},
@@ -54,6 +57,15 @@ func NewEngine(world *World) *Engine {
 	// Lie l'engine au monde pour permettre aux systèmes de communiquer
 	world.Engine = e
 
+	// Tri initial des systèmes par priorité (une seule fois, l'ordre est constant)
+	for i := 0; i < len(e.systems)-1; i++ {
+		for j := i + 1; j < len(e.systems); j++ {
+			if e.systems[i].Priority() > e.systems[j].Priority() {
+				e.systems[i], e.systems[j] = e.systems[j], e.systems[i]
+			}
+		}
+	}
+
 	// S'abonne aux entrées de grille
 	world.EventBus.SubscribeFunc(event.GridEntered, func(ev event.Event) {
 		gridID, _ := ev.Payload["grid_id"].(string)
@@ -72,15 +84,6 @@ func (e *Engine) ResetPreviews() {
 
 // Update fait progresser le tour de jeu
 func (e *Engine) Update() {
-	// Tri des systèmes par priorité
-	for i := 0; i < len(e.systems)-1; i++ {
-		for j := i + 1; j < len(e.systems); j++ {
-			if e.systems[i].Priority() > e.systems[j].Priority() {
-				e.systems[i], e.systems[j] = e.systems[j], e.systems[i]
-			}
-		}
-	}
-
 	for _, sys := range e.systems {
 		sys.Update(e.world)
 	}
@@ -131,26 +134,35 @@ func (e *Engine) Update() {
 	}
 
 	e.world.EventBus.Publish(event.NewTurnEndedEvent(e.world.Turn))
+
+	// Recalcule le cache des entités matchables pour UpdateFrame
+	e.recomputeMatchableCount()
+}
+
+// recomputeMatchableCount vérifie si la grille courante contient au moins une entité matchable (resource ou creature).
+// Le résultat est mis en cache dans hasMatchableEntities pour éviter de rescanner à chaque frame.
+func (e *Engine) recomputeMatchableCount() {
+	e.hasMatchableEntities = false
+	grid, ok := e.world.GetGrid(e.world.CurrentGridID)
+	if !ok {
+		return
+	}
+	for _, tile := range grid.Plots {
+		if len(tile.EntitiesID) > 0 {
+			if ent, ok := e.world.Entities.Get(entity.ID(tile.EntitiesID[len(tile.EntitiesID)-1])); ok {
+				if ent.GetType() == entity.TypeResource || ent.GetType() == entity.TypeCreature {
+					e.hasMatchableEntities = true
+					return
+				}
+			}
+		}
+	}
 }
 
 // UpdateFrame effectue les mises à jour visuelles et les systèmes temps réel (pseudo-systèmes de frame)
 func (e *Engine) UpdateFrame(dt float64) {
-	// 1. Détecter grille vide (aucune entité matchable)
-	isEmptyGrid := false
-	if grid, ok := e.world.GetGrid(e.world.CurrentGridID); ok {
-		hasMatchable := false
-		for _, tile := range grid.Plots {
-			if len(tile.EntitiesID) > 0 {
-				if ent, ok := e.world.Entities.Get(entity.ID(tile.EntitiesID[len(tile.EntitiesID)-1])); ok {
-					if ent.GetType() == entity.TypeResource || ent.GetType() == entity.TypeCreature {
-						hasMatchable = true
-						break
-					}
-				}
-			}
-		}
-		isEmptyGrid = !hasMatchable
-	}
+	// 1. Utilise le cache calculé à la fin du dernier Update()
+	isEmptyGrid := !e.hasMatchableEntities
 
 	// 2. Détecter prévisualisation active
 	isPreviewing := e.previewSystem != nil && e.previewSystem.IsPreviewActive(e.world.CurrentGridID)

--- a/internal/domain/system/world.go
+++ b/internal/domain/system/world.go
@@ -64,6 +64,9 @@ type World struct {
 	// Référence vers l'engine (pour la communication entre systèmes)
 	Engine *Engine
 
+	// Compteur de créatures révélées par espèce (pour species_anger en O(1))
+	RevealedBySpecies map[string]int
+
 	// Debug
 	Debug DebugState
 }
@@ -99,6 +102,7 @@ func NewWorld() *World {
 		tilesFlippedThisTurn: make([]board.Position, 0),
 		lastTurnNumber:       0,
 		TurnTimer:            NewTurnTimer(meta.GetSettings(meta.LevelNormal).TurnTimerDuration),
+		RevealedBySpecies:    make(map[string]int),
 		Debug: DebugState{
 			Difficulty: meta.GetSettings(meta.LevelNormal),
 			MessageSpeed: 1.0,

--- a/internal/domain/system/world_mechanics.go
+++ b/internal/domain/system/world_mechanics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/LIannhic/hunter-gatherers-concentration/internal/domain/board"
+	"github.com/LIannhic/hunter-gatherers-concentration/internal/domain/creature"
 	"github.com/LIannhic/hunter-gatherers-concentration/internal/domain/entity"
 	"github.com/LIannhic/hunter-gatherers-concentration/internal/domain/event"
 )
@@ -50,8 +51,18 @@ func (w *World) FlipTile(gridID string, pos board.Position, flipDir entity.FlipD
 	currentState := ent.GetState()
 	if currentState&entity.Revealed != 0 {
 		ent.SetState(entity.Hidden)
+		// Décrémente le compteur species_anger si c'est une créature qui se cache
+		if c, ok := ent.(*creature.Creature); ok {
+			if w.RevealedBySpecies[c.Species] > 0 {
+				w.RevealedBySpecies[c.Species]--
+			}
+		}
 	} else {
 		ent.SetState(entity.Revealed)
+		// Incrémente le compteur species_anger si c'est une créature qui se révèle
+		if c, ok := ent.(*creature.Creature); ok {
+			w.RevealedBySpecies[c.Species]++
+		}
 	}
 
 	// 6. Transformation diédrique persistante (Composition globale)
@@ -141,6 +152,11 @@ func (w *World) RevealTile(gridID string, pos board.Position, flipDir entity.Fli
 	// 1. Force l'état Revealed (uniquement si pas déjà révélé)
 	if ent.GetState()&entity.Revealed == 0 {
 		ent.SetState(entity.Revealed)
+
+		// Incrémente le compteur species_anger si c'est une créature
+		if c, ok := ent.(*creature.Creature); ok {
+			w.RevealedBySpecies[c.Species]++
+		}
 
 		// 2. Applique la transformation géométrique du flip
 		currentTrans := ent.GetTransformation()

--- a/internal/ui/actionbuttons/manager.go
+++ b/internal/ui/actionbuttons/manager.go
@@ -155,7 +155,7 @@ func (m *Manager) ComputeStates() [btnCount]ButtonState {
 	}
 
 	// --- TROUBLES COGNITIFS ---
-	if p != nil && (p.AphasiaTurns > 0 || p.AtaxiaTurns > 0 || p.AgnosiaTurns > 0 || p.AmnesiaTurns > 0) {
+	if p != nil && (p.AphasiaTurns > 0 || p.AtaxiaTurns > 0 || p.AgnosiaTurns > 0) {
 		m.applyImpairments(p, &states, elapsed)
 	} else {
 		m.resetScramble()
@@ -340,17 +340,6 @@ func (m *Manager) applyImpairments(p *player.Player, states *[btnCount]ButtonSta
 			if m.getTimerProgress != nil {
 				states[i].FillProgress = m.getTimerProgress()
 				states[i].FillAlert = states[i].FillProgress >= 1.0
-			}
-		}
-	}
-
-	// Amnesia : Désactivation partielle
-	if p.AmnesiaTurns > 0 {
-		seed := time.Now().UnixMilli() / 2000
-		r := rand.New(rand.NewSource(seed))
-		for i := 0; i < btnCount; i++ {
-			if r.Float32() < 0.3 {
-				states[i].Active = false
 			}
 		}
 	}

--- a/internal/ui/renderer/board_renderer.go
+++ b/internal/ui/renderer/board_renderer.go
@@ -73,6 +73,10 @@ type BoardRenderer struct {
 	// Effet Lumifly actif (nil si aucun)
 	lumiflyEffect *LumiflyEffect
 
+	// Buffers pré-alloués pour les effets (évite ebiten.NewImage à chaque frame)
+	scannerBuffer *ebiten.Image
+	lumiflyBuffer *ebiten.Image
+
 	// Dernier tour rendu (pour détecter le changement de tour et clear les silhouettes)
 	lastRenderedTurn int
 }
@@ -171,6 +175,24 @@ func NewBoardRenderer(am *assets.Manager) *BoardRenderer {
 	// Initialise le gestionnaire d'animations lié au renderer
 	r.AnimManager = NewAnimationManager(r)
 	return r
+}
+
+// getScannerBuffer retourne le buffer pré-alloué pour l'effet scanner (lazy init).
+func (r *BoardRenderer) getScannerBuffer() *ebiten.Image {
+	if r.scannerBuffer == nil {
+		r.scannerBuffer = ebiten.NewImage(int(ui.PlaymatW), int(ui.PlaymatH))
+	}
+	r.scannerBuffer.Clear()
+	return r.scannerBuffer
+}
+
+// getLumiflyBuffer retourne le buffer pré-alloué pour l'effet lumifly (lazy init).
+func (r *BoardRenderer) getLumiflyBuffer() *ebiten.Image {
+	if r.lumiflyBuffer == nil {
+		r.lumiflyBuffer = ebiten.NewImage(int(ui.PlaymatW), int(ui.PlaymatH))
+	}
+	r.lumiflyBuffer.Clear()
+	return r.lumiflyBuffer
 }
 
 // SetGridOffset change la position du plateau à l'écran
@@ -1679,10 +1701,8 @@ func (r *BoardRenderer) renderScannerEffects(screen *ebiten.Image, gridID string
 		return
 	}
 
-	// 1. Création de l'image source pour le shader (Revealed items)
-	playmatW, playmatH := ui.PlaymatW, ui.PlaymatH
-	srcImg := ebiten.NewImage(int(playmatW), int(playmatH))
-	// On peut remplir avec un fond très sombre pour le style
+	// 1. Image source pour le shader (buffer pré-alloué)
+	srcImg := r.getScannerBuffer()
 	srcImg.Fill(color.RGBA{15, 15, 20, 255})
 
 	// 2. Rendu uniquement des positions scannées
@@ -1709,7 +1729,7 @@ func (r *BoardRenderer) renderScannerEffects(screen *ebiten.Image, gridID string
 
 	// 3. Paramètres de l'animation pour le shader
 	// On balaie de gauche à droite sur toute la largeur du playmat
-	fullWidth := float32(playmatW)
+	fullWidth := float32(ui.PlaymatW)
 	margin := float32(200.0) // Pour que la vague commence/finisse hors champ
 
 	// Progress va de -margin à fullWidth + margin
@@ -1739,8 +1759,7 @@ func (r *BoardRenderer) renderLumiflyEffect(screen *ebiten.Image, world *domain.
 
 	// L'effet doré persiste tant que le tour n'est pas terminé (timer du monde)
 	if !world.TurnTimer.IsExpired() && r.effectRenderer != nil {
-		playmatW, playmatH := ui.PlaymatW, ui.PlaymatH
-		srcImg := ebiten.NewImage(int(playmatW), int(playmatH))
+		srcImg := r.getLumiflyBuffer()
 		srcImg.Fill(color.RGBA{0, 0, 0, 0})
 
 		isPortalZone := world.DreamPlane != nil && (gridID == world.DreamPlane.StartZoneID || gridID == world.DreamPlane.EndZoneID)

--- a/internal/ui/renderer/effect_renderer.go
+++ b/internal/ui/renderer/effect_renderer.go
@@ -28,6 +28,8 @@ var (
 	lumiflyShaderSource []byte
 	//go:embed shader/rain.kage
 	rainShaderSource []byte
+	//go:embed shader/cave.kage
+	caveShaderSource []byte
 )
 
 type EffectRenderer struct {
@@ -53,7 +55,8 @@ func NewEffectRenderer() (*EffectRenderer, error) {
 		"vortex":  vortexShaderSource,
 		"quake":   quakeShaderSource,
 		"lumifly": lumiflyShaderSource,
-		"rain": rainShaderSource,
+		"rain":    rainShaderSource,
+		"cave":    caveShaderSource,
 	}
 
 	for name, src := range sources {
@@ -217,17 +220,26 @@ func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params Globa
 		r.applyShader(src, dst, "rain", shaderIntensity, nil, params.ScreenSize)
 		src, dst = dst, src // Ping-pong
 		anyApplied = true
+	} else if params.Biome == "cave" {
+		hudLights := r.buildHudLights()
+		r.applyCaveShader(src, dst, shaderIntensity, params.ScreenSize, hudLights)
+		src, dst = dst, src // Ping-pong
+		anyApplied = true
 	}
 
-	// 2. Creature Attack Effects
+	// 2. Creature Attack Effects — mapping linéaire [min, 1.0] sur la plage de sanité
 	if params.UseBubble {
-		r.applyShader(src, dst, "bubble", shaderIntensity, params.MousePos, params.ScreenSize)
+		bubbleMin := float32(0.45) // Min 88px radius = taille d'une tuile
+		bubbleIntensity := bubbleMin + (1.0-bubbleMin)*intensity
+		r.applyShader(src, dst, "bubble", bubbleIntensity, params.MousePos, params.ScreenSize)
 		src, dst = dst, src
 		anyApplied = true
 	}
 
 	if params.UseBlur {
-		r.applyShader(src, dst, "blur", shaderIntensity, nil, params.ScreenSize)
+		blurMin := float32(0.4) // Min 0.8px offset = flou léger perceptible
+		blurIntensity := blurMin + (1.0-blurMin)*intensity
+		r.applyShader(src, dst, "blur", blurIntensity, nil, params.ScreenSize)
 		src, dst = dst, src
 		anyApplied = true
 	}
@@ -249,6 +261,41 @@ func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params Globa
 	if anyApplied {
 		screen.DrawImage(src, nil)
 	}
+}
+
+// buildHudLights retourne les cercles de lumière pour les panneaux HUD.
+// Format plat [cx, cy, radius, 0, ...] × 4 éléments (pixels écran).
+func (r *EffectRenderer) buildHudLights() []float32 {
+	// Portrait : centre (145,145), rayon ~190 (couvre le carré 270×270)
+	// Inventaire : centre (145,525), rayon ~230 (couvre 270×370)
+	// Jauges : centre (1135,220), rayon ~210 (couvre 270×320)
+	// Minimap : centre (1135,575), rayon ~190 (couvre 270×270)
+	return []float32{
+		145, 145, 190, 0,
+		145, 525, 230, 0,
+		1135, 220, 210, 0,
+		1135, 575, 190, 0,
+	}
+}
+
+func (r *EffectRenderer) applyCaveShader(src, dst *ebiten.Image, intensity float32, resolution, hudLights []float32) {
+	shader, ok := r.shaders["cave"]
+	if !ok {
+		return
+	}
+
+	dst.Clear()
+	op := &ebiten.DrawRectShaderOptions{}
+	op.Images[0] = src
+	op.Uniforms = map[string]interface{}{
+		"Time":       float32(r.count) / 60.0,
+		"Intensity":  intensity,
+		"Resolution": resolution,
+		"HudLights":  hudLights,
+	}
+
+	sw, sh := src.Bounds().Dx(), src.Bounds().Dy()
+	dst.DrawRectShader(sw, sh, shader, op)
 }
 
 func (r *EffectRenderer) applyShader(src, dst *ebiten.Image, name string, intensity float32, center []float32, resolution []float32) {

--- a/internal/ui/renderer/shader/blur.kage
+++ b/internal/ui/renderer/shader/blur.kage
@@ -8,8 +8,8 @@ var Resolution vec2
 func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
     clr := vec4(0, 0, 0, 0)
     samples := 9
-    // Décalage en pixels (environ 2 pixels à intensité max)
-    offset := 2.0 * Intensity
+    // Décalage en pixels (environ 5 pixels à intensité max)
+    offset := 5.0 * Intensity
 
     clr += imageSrc0At(srcPos + vec2(-offset, -offset))
     clr += imageSrc0At(srcPos + vec2(0, -offset))

--- a/internal/ui/renderer/shader/cave.kage
+++ b/internal/ui/renderer/shader/cave.kage
@@ -1,0 +1,89 @@
+//kage:unit pixels
+
+package main
+
+var Time float
+var Intensity float // 0.0 = 100% Sanity | 0.5 = 50% Sanity | 1.0 = 0% Sanity
+var Resolution vec2
+var HudLights [16]float // [cx, cy, radius, _, ...] × 4 éléments
+
+func hash12(p vec2) float {
+	return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123)
+}
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	distPixels := length(dstPos.xy - (Resolution * 0.5))
+	tileSize := 87.5
+
+	// === 1. RAYON DE LA TORCHE ===
+	var targetRadius float
+	if Intensity < 0.5 {
+		targetRadius = mix(2.0, 1.2, Intensity*2.0) * tileSize
+	} else {
+		targetRadius = mix(1.2, 0.15, (Intensity-0.5)*2.0) * tileSize
+	}
+
+	// === 2. FORCE ET VACILLEMENT ===
+	flickerNoise := hash12(vec2(floor(Time*14.0), 12.34))
+
+	var torchForce float
+	var flickerAmp float
+	if Intensity < 0.5 {
+		t := Intensity * 2.0
+		torchForce = mix(0.35, 0.55, t)
+		flickerAmp = mix(0.03, 0.10, t)
+	} else {
+		t := (Intensity - 0.5) * 2.0
+		torchForce = mix(0.70, 0.95, t)
+		flickerAmp = mix(0.10, 0.30, t)
+	}
+	currentTorchFactor := torchForce + (flickerNoise-0.5)*flickerAmp
+
+	// === 3. OBSCURITÉ DE FOND ===
+	var maxDarkness float
+	if Intensity < 0.5 {
+		maxDarkness = mix(0.55, 0.75, Intensity*2.0)
+	} else {
+		maxDarkness = mix(0.75, 0.90, (Intensity-0.5)*2.0)
+	}
+
+	// === 4. VIGNETTE DE LA TORCHE ===
+	innerGlow := targetRadius * 0.4
+	outerGlow := targetRadius
+	torchVignette := smoothstep(innerGlow, outerGlow, distPixels)
+
+	// === 5. COMPOSITION ===
+	baseColor := imageSrc0At(srcPos)
+	caveBlack := vec4(0.01, 0.01, 0.02, 1.0)
+	litColor := baseColor * currentTorchFactor
+
+	darknessMix := torchVignette * maxDarkness
+	finalColor := mix(litColor, caveBlack, darknessMix)
+
+	// === 6. LIGHTS HUD — cercles de lumière contraints aux panneaux ===
+	// [cx, cy, radius, _] × 4 éléments. Le rayon ne dépasse jamais radius.
+	if Intensity > 0.0 {
+		hudLight := 0.0
+		// L'ombre interne (smoothstep) rétrécit avec l'intensité → la lumière "grandit"
+		edge := mix(0.85, 0.15, Intensity)
+
+		for i := 0; i < 16; i += 4 {
+			cx := HudLights[i]
+			cy := HudLights[i+1]
+			r := HudLights[i+2]
+
+			dist := length(dstPos.xy - vec2(cx, cy))
+			light := 1.0 - smoothstep(r*edge, r, dist)
+			if light > hudLight {
+				hudLight = light
+			}
+		}
+
+		if hudLight > 0.0 {
+			litHud := baseColor * currentTorchFactor
+			finalColor = mix(finalColor, litHud, hudLight*0.95)
+		}
+	}
+
+	return finalColor
+}


### PR DESCRIPTION
…ns perf

- Cave shader (cave.kage) : obscurité oppressive, torche centrale, cercles de lumière HUD (Portrait, Inventaire, Jauges, Minimap) contraints aux panneaux
- Blur shader : multiplicateur augmenté de 2.0 à 5.0
- EffectRenderer : applyCaveShader avec uniform HudLights, buildHudLights
- BoardRenderer : buffers scanner/lumifly pré-alloués (lazy init)
- Engine : tri des systems déplacé dans NewEngine, cache hasMatchableEntities
- Entity Manager : cache GetAllActive avec dirty flag
- Component Store : reverse index byComponent pour QueryByComponent
- AggressionSystem : compteur RevealedBySpecies en O(1) au lieu de scan O(C×E)
- ActionButtons : suppression de la désactivation partielle des boutons (amnésie)
- ARCHITECTURE.md : documentation cave shader ajoutée