### PR TITLE
feat: add tile action frames (cadres d'action hybrides)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -353,6 +353,7 @@ Système de traces visuelles laissées par les créatures lors de leurs déplace
 ### 4. UI
 
 Le jeu utilise une résolution logique fixe de **1280x720**. L'interface est divisée en plusieurs zones gérées par le `HUD` :
+- **`ui/layout.go`** : Constantes de disposition et types UI partagés (ex: `TileActionState` pour les cadres d'action).
 - **Portrait** (270x270) : Affiche les statistiques du personnage, les contrôles et le contenu dynamique de la zone.
 - **Inventaire** (270x420) : Grille 3x4 pour les objets récoltés.
 - **Playmat** (700x700) : Zone centrale contenant le plateau de jeu (525x525), les boutons d'action et les indicateurs de sortie.
@@ -371,9 +372,11 @@ Séparation des responsabilités :
     - **Plateau (Board)** : 525x525. Contient les tuiles et les traces.
     - **Tapis de Jeu (Playmat)** : 700x700. Contient le plateau, les boutons et les **Effets Plein Écran** (ex: Scanner de l'Echo Hound).
   - **Barre d'Agressivité** : Sur les créatures révélées (`Aggression > 0`), dessine une barre horizontale (40x4px) en bas de la tuile. Couleur dégradée : Orange (faible) → Rouge (100%). Fond semi-transparent noir.
+  - **Cadres d'Action** : Rendu des cadres colorés (`StrokeRect` 3px) via `RenderTileActionFrame()`. Couleurs : Vert (interactive), Rouge (impossible), Orange (indisponible). Cadre permanent sur la 1ère tuile révélée, au survol pour les autres.
 - **Input**: Capture les événements (clavier, souris, tactile), gère la navigation entre les zones et les raccourcis clavier. 
   - **Unification Cross-Platform** : Utilise `GetInteractionPosition()` (priorise le tactile sur le curseur) et `IsJustPressed()` / `IsJustReleased()` pour garantir une réactivité identique entre Desktop et WASM/Mobile.
   - **Interactions Tactiles** : Supporte le défilement de l'inventaire par glissement (Drag-to-scroll) et l'appui long pour la suppression.
+  - **Cadres d'Action** : Système hybride de feedback visuel sur les tuiles. `computeTileActionState()` évalue l'état d'interaction (vert/rouge/orange) en croisant `isProcessing`, `TileState`, `ImmunityTurns`, animations de mouvement et mana. Rendu via `RenderTileActionFrame()` dans le renderer (cadre `StrokeRect` 3px). Cadre permanent sur la 1ère tuile révélée, au survol pour les autres.
 - **HUD**: Orchestre l'affichage des informations fixes et des fenêtres volantes (ex: Statistiques des zones).
   - **Système de Messages Défilants**: Gère deux zones de notification indépendantes (**Gauche** et **Droite**) avec des files d'attente prioritaires. Chaque message défile de droite à gauche deux fois avant de disparaître.
     - **Zone Gauche**: Affiche les messages narratifs et les effets d'utilisation d'objets (ex: "Vous êtes déboussolé.", "Vous toussez du sang.", "La mémoire revient...").

--- a/README.md
+++ b/README.md
@@ -310,6 +310,36 @@ L'interface assiste le joueur dans sa gestion des ressources via un système de 
 - **Anti-Triche** : Aucun feedback de coût n'est affiché au survol des tuiles cachées pour éviter de divulguer des informations sur leur nature (créature vs ressource).
 - **Rendu Sélectif** : Les tuiles cumulées n'apparaissent plus grandes et dorées que lorsqu'elles sont **Révélées**. À l'état caché, elles sont identiques aux tuiles normales. **Bordures de cumul** : Les tuiles cumulées affichent des bordures concentriques fines dont la couleur évolue avec le niveau (vert → jaune → orange → rouge).
 
+### Cadres d'Action (Tile Action Frames)
+
+Un système de **cadres colorés** guide le joueur en indiquant l'état d'interaction possible sur chaque tuile. Le rendu est **hybride** :
+
+| Situation | Affichage |
+|-----------|-----------|
+| **1ère tuile révélée ce tour** | Cadre **vert permanent** — montre ce que le joueur a fait |
+| **Survol d'une tuile** | Cadre coloré selon l'état d'action |
+| **Autres tuiles** | Aucun cadre |
+
+#### Couleurs des cadres
+
+| Couleur | État | Condition |
+|---------|------|-----------|
+| **Vert** | Interactive | Tuile cachée, non bloquée, mana suffisant, tour disponible |
+| **Rouge** | Impossible | Tuile révélée/appairée/bloquée, mana insuffisant, 2 tuiles déjà révélées, traitement en cours |
+| **Orange** | Indisponible | Immunité active (Shadowstalker), créature en mouvement sur la case |
+
+#### Logique d'évaluation
+
+L'état est calculé par `computeTileActionState()` dans `handler.go` en croisant les mêmes conditions que `RevealTileCommand.CanExecute()` :
+- `isProcessing` → Rouge (flip en cours)
+- `ImmunityTurns > 0` → Orange
+- Entité en mouvement (`moving_animation`) → Orange
+- `Revealed` / `Matched` / `Blocked` → Rouge
+- `len(revealedEntities) >= 2` → Rouge
+- Mana insuffisant pour tuile cumulée → Rouge
+- Piège révélé avec 1 seule tuile révélée → Vert (défaussable)
+- Sinon → Vert
+
 ### Notifications Défilantes (HUD)
 
 Pour maintenir l'immersion tout en informant le joueur, le HUD intègre deux zones de messages dynamiques :

--- a/internal/domain/README.md
+++ b/internal/domain/README.md
@@ -115,6 +115,7 @@ func (s *LifecycleSystem) Update(world *World) {
 - Un système plus flexible pour les entités spéciales (ex: les portails de commencement qui se bloquent après un délai)
 - **Unification de l'interface `Hoverable`** : Toutes les entités interactives (tuiles, butin) et les sorties implémentent `Hoverable`, permettant un effet d'inclinaison (tilt) unifié au survol.
 - **Système de Cumul (Merge)** : Une mécanique permettant de fusionner des paires identiques pour augmenter leur valeur visuelle et stratégique avant la capture.
+- **Système de Cadres d'Action** : Feedback hybride (permanent sur sélection + au survol) indiquant l'état d'interaction via `TileActionState` (None/Interactive/Impossible/Unavailable). Logique centralisée dans `handler.go:computeTileActionState()`, rendu dans `board_renderer.go:RenderTileActionFrame()`.
 
 ---
 

--- a/internal/ui/input/handler.go
+++ b/internal/ui/input/handler.go
@@ -19,12 +19,23 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
+// TileActionState alias pour ui.TileActionState (évite la duplication)
+type TileActionState = ui.TileActionState
+
+const (
+	TileActionNone         = ui.TileActionNone
+	TileActionInteractive  = ui.TileActionInteractive
+	TileActionImpossible   = ui.TileActionImpossible
+	TileActionUnavailable  = ui.TileActionUnavailable
+)
+
 type Renderer interface {
 	GetTileSize() int
 	GetGridOffset() (int, int)
 	ScreenToGrid(screenX, screenY int, world *domain.World) (board.Position, string, bool)
 	ScreenToLocalTile(screenX, screenY int, world *domain.World) (localX, localY int, gridID string, ok bool)
 	RenderSelectionHighlight(screen *ebiten.Image, pos board.Position, gridID string, color color.Color, world *domain.World)
+	RenderTileActionFrame(screen *ebiten.Image, pos board.Position, gridID string, state TileActionState, world *domain.World)
 	RenderPortalPlacementPreview(screen *ebiten.Image, center board.Position, gridID string, world *domain.World)
 	NotifyHover(entityID string, dir entity.FlipDirection)
 	DecayHoverStates(activeThisFrame map[string]bool)
@@ -1603,52 +1614,25 @@ func (h *Handler) renderHighlights(screen *ebiten.Image) {
 		}
 	}
 
-	// Highlight de la tuile survolée (ne s'affiche que si entité présente ET pas inventaire)
-	if hovered, gridID, ok := h.getHoveredTile(); ok {
-		if gridID == board.InventoryGridID {
-			return
+	// 1. CADRE PERMANENT sur la 1ère tuile révélée ce tour
+	if len(h.revealedEntities) == 1 {
+		ent, ok := h.world.Entities.Get(entity.ID(h.revealedEntities[0]))
+		if ok {
+			pos := ent.GetPosition()
+			gridID := h.revealedGridIDs[0]
+			if gridID == "" {
+				gridID = h.world.CurrentGridID
+			}
+			h.renderer.RenderTileActionFrame(screen, pos, gridID, TileActionInteractive, h.world)
 		}
-		grid, ok := h.world.GetGrid(gridID)
-		if !ok {
-			return
-		}
-
-		tile, err := grid.Get(hovered)
-		if err != nil {
-			return
-		}
-
-		if len(tile.EntitiesID) == 0 {
-			return
-		}
-
-		topID := tile.EntitiesID[len(tile.EntitiesID)-1]
-		ent, ok := h.world.Entities.Get(entity.ID(topID))
-		if !ok {
-			return
-		}
-
-		var highlightColor color.Color
-		state := ent.GetState()
-		if state&entity.Hidden != 0 {
-			highlightColor = color.RGBA{255, 255, 0, 100}
-		} else if state&entity.Revealed != 0 {
-			highlightColor = color.RGBA{0, 255, 255, 100}
-		} else {
-			highlightColor = color.RGBA{255, 255, 255, 50}
-		}
-
-		h.renderer.RenderSelectionHighlight(screen, hovered, gridID, highlightColor, h.world)
 	}
 
-	if h.selectedTile != nil {
-		h.renderer.RenderSelectionHighlight(
-			screen,
-			*h.selectedTile,
-			h.selectedGridID,
-			color.RGBA{255, 0, 0, 150},
-			h.world,
-		)
+	// 2. CADRE AU SURVOL sur la case survolée
+	if hovered, gridID, ok := h.getHoveredTile(); ok && gridID != board.InventoryGridID {
+		actionState := h.computeTileActionState(hovered, gridID)
+		if actionState != TileActionNone {
+			h.renderer.RenderTileActionFrame(screen, hovered, gridID, actionState, h.world)
+		}
 	}
 }
 
@@ -1670,6 +1654,68 @@ func (h *Handler) GetRevealedTiles() int {
 
 func (h *Handler) GetRevealedEntities() []string {
 	return h.confirmedRevealedEntities
+}
+
+// computeTileActionState évalue l'état d'action d'une tuile pour le cadre coloré
+func (h *Handler) computeTileActionState(pos board.Position, gridID string) TileActionState {
+	grid, ok := h.world.GetGrid(gridID)
+	if !ok {
+		return TileActionNone
+	}
+
+	plot, err := grid.Get(pos)
+	if err != nil || len(plot.EntitiesID) == 0 {
+		return TileActionNone
+	}
+
+	topID := plot.EntitiesID[len(plot.EntitiesID)-1]
+	ent, ok := h.world.Entities.Get(entity.ID(topID))
+	if !ok {
+		return TileActionNone
+	}
+
+	// Rouge : traitement en cours (flip d'une autre tuile)
+	if h.isProcessing {
+		return TileActionImpossible
+	}
+
+	state := ent.GetState()
+
+	// Orange : immunité active (Shadowstalker)
+	if h.world.Player != nil && h.world.Player.ImmunityTurns > 0 {
+		return TileActionUnavailable
+	}
+
+	// Orange : créature en mouvement sur cette case
+	for _, movingID := range h.world.Components.QueryByComponent("moving_animation") {
+		if movingID == topID {
+			return TileActionUnavailable
+		}
+	}
+
+	// Rouge : déjà révélée, appairée ou bloquée
+	if state&entity.Revealed != 0 || state&entity.Matched != 0 || state&entity.Blocked != 0 {
+		// Exception : piège révélé qu'on peut défausser (1 seul révélé)
+		if ent.GetType() == entity.TypeTrap && state&entity.Revealed != 0 && state&entity.Matched == 0 {
+			if len(h.revealedEntities) == 1 && h.revealedEntities[0] == string(ent.GetID()) {
+				return TileActionInteractive
+			}
+		}
+		return TileActionImpossible
+	}
+
+	// Rouge : 2 tuiles déjà révélées ce tour
+	if len(h.revealedEntities) >= 2 {
+		return TileActionImpossible
+	}
+
+	// Rouge : mana insuffisant pour tuile cumulée
+	if ent.GetCumulationLevel() > 0 && h.world.Player.Stats.Mana < ent.GetCumulationLevel() {
+		return TileActionImpossible
+	}
+
+	// Vert : action possible
+	return TileActionInteractive
 }
 
 func (h *Handler) ClearSelection() {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,5 +1,15 @@
 package ui
 
+// TileActionState représente l'état d'action d'une tuile pour le cadre coloré
+type TileActionState int
+
+const (
+	TileActionNone         TileActionState = iota // Pas de cadre
+	TileActionInteractive                         // Vert : action possible
+	TileActionImpossible                          // Rouge : action impossible
+	TileActionUnavailable                         // Orange : temporairement indisponible
+)
+
 // Layout constants for 1280x720 screen
 const (
 	ScreenWidth  = 1280

--- a/internal/ui/renderer/board_renderer.go
+++ b/internal/ui/renderer/board_renderer.go
@@ -1774,6 +1774,38 @@ func (r *BoardRenderer) RenderSelectionHighlight(screen *ebiten.Image, pos board
 	vector.StrokeRect(screen, float32(x), float32(y), float32(r.tileSize), float32(r.tileSize), 3, finalColor, true)
 }
 
+// RenderTileActionFrame dessine un cadre coloré autour d'une tuile selon son état d'action
+func (r *BoardRenderer) RenderTileActionFrame(screen *ebiten.Image, pos board.Position, gridID string, state ui.TileActionState, world *domain.World) {
+	if state == ui.TileActionNone {
+		return
+	}
+
+	grid, ok := world.GetGrid(gridID)
+	if !ok {
+		return
+	}
+
+	isPortalZone := world.DreamPlane != nil && (gridID == world.DreamPlane.StartZoneID || gridID == world.DreamPlane.EndZoneID)
+	x, y := r.calculateTileScreenPos(pos, grid, isPortalZone)
+
+	var frameColor color.Color
+	switch state {
+	case ui.TileActionInteractive:
+		frameColor = color.RGBA{80, 200, 120, 220} // Vert
+	case ui.TileActionImpossible:
+		frameColor = color.RGBA{220, 60, 60, 200} // Rouge
+	case ui.TileActionUnavailable:
+		frameColor = color.RGBA{220, 150, 40, 200} // Orange
+	}
+
+	// Effet d'immunité : couleur remplacée par gris
+	if world.Player != nil && world.Player.ImmunityTurns > 0 {
+		frameColor = color.RGBA{150, 150, 160, 200}
+	}
+
+	vector.StrokeRect(screen, float32(x), float32(y), float32(r.tileSize), float32(r.tileSize), 3, frameColor, true)
+}
+
 func (r *BoardRenderer) RenderPortalPlacementPreview(screen *ebiten.Image, center board.Position, gridID string, world *domain.World) {
 	grid, ok := world.GetGrid(gridID)
 	if !ok {


### PR DESCRIPTION
- Add TileActionState enum (None/Interactive/Impossible/Unavailable) in ui/layout.go
- Add computeTileActionState() in handler.go to evaluate action state per tile
- Add RenderTileActionFrame() in board_renderer.go for colored frame rendering
- Hybrid display: permanent green frame on first revealed tile, colored frames on hover
- Green = interactive (can flip), Red = impossible, Orange = temporarily unavailable
- Update renderHighlights() to use new tile action frame system
- Update documentation (README.md, ARCHITECTURE.md, domain/README.md)