### PR TITLE
feat: shader vertige Fleeing Sprite + optimisations rendu/perf

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ Le domaine utilise une architecture **Entity-Component-System (ECS)** amélioré
   - **TrackSystem** : Gère la décomposition temporelle des traces (décrément de `Duration` à chaque tour, suppression définitive à 0).
   - **AggressionSystem** : Calcule l'agressivité modulaire des créatures (Priority 1, avant mouvement). S'abonne à `TileRevealed` (reason: "player_action") pour incrémenter `RevealCount` et mettre à jour le facteur "reveals". S'abonne à `CreatureMoved` pour gérer la "patience" (+2% par pas, +10% par rebond). Déclenche l'attaque si agressivité totale ≥ 100 à la fin de l'animation de flip.
 
-- **CreatureAttackEffectSystem** : Centralise les conséquences logiques mondiales des attaques réussies. S'abonne à `CreatureAttacked` et applique des changements permanents ou majeurs au monde (ex: rotation de grille du Stonewarden, déclenchement des troubles cognitifs Aphasia, Ataxia, Agnosia, Amnesia — uniquement si `hit_target` présent dans le payload, i.e. attaque qui touche le joueur).
+- **CreatureAttackEffectSystem** : Centralise les conséquences logiques mondiales des attaques réussies. S'abonne à `CreatureAttacked` et applique des changements permanents ou majeurs au monde (ex: rotation de grille du Stonewarden, déclenchement des troubles cognitifs Aphasia, Ataxia, Agnosia, Amnesia, Vertigo — uniquement si `hit_target` présent dans le payload, i.e. attaque qui touche le joueur).
 
 - **ComboSystem** (Priority 10) : Gère le système de combo (associations consécutives). S'abonne à `TileMatched` pour incrémenter le compteur et calculer la juiciness (1-5). S'abonne à `TileMerged` pour publier un message sans incrémenter. S'abonne à `PlayerDamaged` pour réinitialiser le combo en cas d'erreur (`invalid_match`, `skipped_valid_match`). Publie `ComboTriggered` via `PublishImmediate` (sinon perdu dans `ProcessQueue`). Le message est rendu par le HUD dans la `ComboZone` (270×40px, en haut à droite) avec un fond coloré par niveau, un outline noir 8-directions, et un slide-in depuis la droite.
 
@@ -140,7 +140,7 @@ Le domaine utilise une architecture **Entity-Component-System (ECS)** amélioré
   - `ImmunityTurns` : Géré dans `Player`, permet de bloquer tous les dégâts. Utilisé par l'effet du Shadowstalker.
 
 - **StatusEffects** (`player/status.go`) : Altérations mentales du joueur
-  - `Aphasia`, `Agnosia`, `Ataxia`, `Amnesia`
+  - `Aphasia`, `Agnosia`, `Ataxia`, `Amnesia`, `Vertigo`
   - Interceptées par le rendu UI pour scrambler les coordonnées/labels des boutons d'action
 
 - **Types d'entités** :
@@ -381,7 +381,11 @@ Séparation des responsabilités :
   - **Système de Messages Défilants**: Gère deux zones de notification indépendantes (**Gauche** et **Droite**) avec des files d'attente prioritaires. Chaque message défile de droite à gauche deux fois avant de disparaître.
     - **Zone Gauche**: Affiche les messages narratifs et les effets d'utilisation d'objets (ex: "Vous êtes déboussolé.", "Vous toussez du sang.", "La mémoire revient...").
     - **Zone Droite**: Affiche les feedbacks de gameplay immédiats (ex: "CONFRONTATION ! -10 HP", "TOXICITÉ ! -X HP", "AMNÉSIE ! X tours.", "MATCH INVALIDE !").
-- **EffectRenderer** (`renderer/effect_renderer.go`) : Gère les shaders globaux (Wave, Heat, Bubble, Blur, Lumifly, Cave) avec un système de ping-pong buffers. L'intensité des effets est couplée dynamiquement à la **Santé Mentale** du joueur. Peut être forcé via la **Console de Debug**.
+- **EffectRenderer** (`renderer/effect_renderer.go`) : Gère les shaders globaux via un système de ping-pong buffers. L'intensité des effets est couplée dynamiquement à la **Santé Mentale** du joueur. Peut être forcé via la **Console de Debug**.
+  - **Séparation Attack/Biome** : Les shaders sont splités en deux méthodes pour un rendu correct :
+    - `ProcessCreatureAttackEffects()` : Blur, Bubble, Vertige — appliqués **AVANT** le HUD pour ne pas affecter les fenêtres UI.
+    - `ProcessBiomeEffects()` : Wave, Heat, Rain, Cave, Vortex — appliqués **APRÈS** le HUD (comportement original).
+  - **Quake Shader** : Rendu **AVANT** tous les shaders (comme Scanner/Lumifly).
   - **Lumifly Shader** (`renderer/shader/lumifly.kage`) : Onde lumineuse dorée circulaire avec silhouettes d'entités. Centre calculé via `calculateTileScreenPos` pour un alignement parfait avec les tuiles. Rayon basé sur la diagonale d'une case (`√2`).
   - **Silhouettes sur le Dos** : Chaque tuile affiche la silhouette de son entité sur le dos (alpha variable), utilisée par le shader Lumifly pour les effets de révélation. Les UVs du dos sont transformés par la D4 avec miroir horizontal.
 
@@ -389,7 +393,7 @@ Séparation des responsabilités :
   - **Snapshot** (`playmatSnapshot`) : Capture de 990×990 (playmat 700×700 + `QuakePadding` = 145px par côté) pour éviter les espaces vides lors de la rotation.
   - **Frame Buffer** (`quakeFrameBuffer`) : 990×990, reçoit la sortie du shader, puis `SubImage` centre 700×700 affiché à `(PlaymatX, PlaymatY)`.
   - **Uniforms** : `RotationAngle` (Pi/2 ou -Pi/2), `Clockwise` (bool), `GhostSize` [990,990], `Resolution` [990,990].
-  - **Rendu** : `RenderQuakeOverlay` appelé après `ProcessGlobalEffects` pour le plus haut z-index.
+  - **Rendu** : `RenderQuakeOverlay` appelé **AVANT** les shaders globaux (comme Scanner/Lumifly), puis shaders attack, puis HUD, puis shaders biome.
 
 - **Cave Shader** (`renderer/shader/cave.kage`) : Effet d'ambiance oppressive pour le biome grotte. Couplé à la **Santé Mentale** du joueur via le paramètre `Intensity` (0.0 = sane, 1.0 = folie totale).
   - **Obscurité de fond** : Assombrit uniformément l'écran (55% à sanity满 → 98% à sanity 0). La torche centrale crée un cercle de lumière proportionnel à la folie.
@@ -601,7 +605,7 @@ type MovementProfile struct {
 | **Stonewarden** | OnReveal         | Orientation            | Manifest | Normal | 40 | attaque = rotation grille 90° + shader quake |
 | **Moss Monkey** | Proximité (4)    | Attraction (Empty)     | Manifest | Normal | 0 (dynamique) |
 | **Flutterwing** | Proximité (2)    | Répulsion (Player)     | Manifest | Over | 0 |
-| **Fleeing Sprite** | Proximité (3)    | Répulsion (Player)     | Manifest | Normal | 0 |
+| **Fleeing Sprite** | Proximité (3)    | Répulsion (Player)     | Manifest | Normal | 0 | Fuit le joueur. Attaque : **Vertige** (distorsion + aberration chromatique). Butin : Vision des Intentions. |
 
 #### Types de navigation
 
@@ -690,7 +694,7 @@ Chaque créature a un composant `Behavior` enrichi :
 L'attaque ne se produit **pas** à la révélation, mais à la **fin de l'animation de flip** (`AnimationEnded`, type="flip", state=Revealed). Si `Aggression >= 100` :
 1. Vérifie si le joueur est dans la `ThreatZone` (même logique périphérique qu'avant).
 2. Publie `CreatureAttacked` (payload: `hit_target` = position joueur si menacé, nil sinon) → Renderer lance l'animation de lunge.
-3. Si joueur menacé et pas de *Grâce* : `TakeDamage(10, "physical")` + `PlayerDamaged` event + effets visuels (Blur Shadowstalker, Bulle Lumifly).
+3. Si joueur menacé et pas de *Grâce* : `TakeDamage(10, "physical")` + `PlayerDamaged` event + effets visuels (Blur Shadowstalker, Bulle Lumifly, Vertige Fleeing Sprite).
 
 #### Difficulté
 `MaxSafeReveals` et `AggressionMult` dans `DifficultySettings` contrôlent la tolérance et l'intensité globale.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ Lorsqu'une créature est révélée (fin d'animation de flip), si son **Agressiv
 - **Condition de Succès** : Les dégâts et effets ne s'appliquent que si l'attaque **touche** le joueur. Si l'attaque ne touche pas, le joueur n'a rien.
 - Inflige **10 dégâts physiques** (sauf si *Grâce* active).
 - **Effets Spécifiques au Monde** : Centralisés par le `CreatureAttackEffectSystem`.
-  - **Stonewarden** : Son attaque provoque un séisme de rotation (pivote la grille de 90°).
-  - **Echo Hound** : Déclenche l'état **Aphasia** (3 tours).
-  - **Burrower** : Déclenche l'état **Ataxia** (3 tours).
-  - **Moss Monkey** : Déclenche l'état **Agnosia** et l'effet visuel de **Mousse Coulante** (3 tours).
-  - **Specter** : Déclenche l'état **Amnesia** (5 tours).
-- Déclenche des effets visuels selon l'espèce (Blur pour Shadowstalker, Bulle pour Lumifly).
+- **Stonewarden** : Son attaque provoque un séisme de rotation (pivote la grille de 90°).
+   - **Echo Hound** : Déclenche l'état **Aphasia** (3 tours).
+   - **Burrower** : Déclenche l'état **Ataxia** (3 tours).
+   - **Moss Monkey** : Déclenche l'état **Agnosia** et l'effet visuel de **Mousse Coulante** (3 tours).
+   - **Specter** : Déclenche l'état **Amnesia** (5 tours).
+   - **Fleeing Sprite** : Déclenche l'état **Vertige** et le shader **Vertige** (3 tours).
+- Déclenche des effets visuels selon l'espèce (Blur pour Shadowstalker, Bulle pour Lumifly, Vertige pour Fleeing Sprite).
 - Publie l'événement `CreatureAttacked` pour l'animation et `PlayerDamaged` pour le HUD.
 
 #### Feedback Visuel
@@ -356,8 +357,7 @@ Le joueur peut subir des altérations mentales qui déforment radicalement l'int
 - **Agnosia** (Moss Monkey) – Rend les boutons visuellement indifférenciés via un **Thème Monochrome standardisé**. Les boutons deviennent noirs avec un contenu blanc, et leurs labels affichent tous **"BOUTON"**.
 - **Effacement par le Timer** (Agnosia) – La jauge de remplissage du timer s'applique aux 4 boutons et progresse du **Noir vers le BLANC**. À 100%, elle masque totalement le texte et l'icône, rendant le bouton anonyme.
 - **Amnesia** (Specter) – Les tuiles butins sont face cachée. Déclenché par le Spectre lorsqu'une attaque touche le joueur ou la proximité d'une void bloom. Les tuiles de l'inventaire se retournent vers une direction dictée par l'ancrage du joueur (le Spectre "frotte" les objets dans le sens de son passage). Affiche "AMNÉSIE ! X tours." sur la zone droite et "Vous avez du mal à vous souvenir." sur la zone gauche. À la fin, "La mémoire revient..." et l'inventaire est révélé automatiquement.
-
-Ces effets sont interceptés par le système de rendu **avant** l'affichage, forçant le joueur à lutter contre sa propre interface.
+- **Vertige** (Fleeing Sprite) – Le monde tourne autour de vous. Déclenche un shader de **distorsion radiale** avec aberration chromatique (séparation R/G/B) et pulsation de panique. Les couleurs se séparent et l'image tremble, simulant une désorientation visuelle.
 
 Ces effets sont interceptés par le système de rendu **avant** l'affichage, forçant le joueur à lutter contre sa propre interface.
 
@@ -469,7 +469,7 @@ Le joueur dispose d'un indicateur visuel persistant montrant sa position actuell
 | **Echo Hound** | Marais | Auto | Relatif | Swap | Rebond | 50 | Chien rapide qui échange de place avec la cible et rebondit 180° quand bloqué (Exclusif). |
 | **Moss Monkey** | Forêt | Proximité (4) | Target Empty | Normal | Glisse | 0 (dynamique) | Saboteur qui rebouche les cases vides. Agressivité = % cases vides. Fuit si saturé. |
 | **Flutterwing** | Global | Proximité (2) | Répulsion joueur | Over | Glisse | 0 | Créature timide dont l'essence apaise l'esprit. |
-| **Fleeing Sprite** | Global | Proximité (3) | Répulsion joueur | Normal | Glisse | 0 | Étincelle d'énergie vive révélant les dangers. |
+| **Fleeing Sprite** | Global | Proximité (3) | Répulsion joueur | Normal | Glisse | 0 | Étincelle d'énergie vive qui fuit le joueur. Attaque : **Vertige** (distorsion + aberration chromatique). Butin : Vision des Intentions (révèle les zones de menace). |
 
 ### Système de Cycle Cyclique (Lifecycle)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1030,13 +1030,37 @@ func (app *Application) drawPlaying(screen *ebiten.Image) {
 
 	app.Renderer.Render(screen, app.World)
 	app.Input.Draw(screen)
-	app.HUD.Render(screen)
 
-	if app.World.Debug.Visible {
-		app.DebugWindow.Render(screen)
+	// Quake AVANT tous les shaders (comme scanner/lumifly)
+	app.Renderer.RenderQuakeOverlay(screen, app.World)
+
+	// Application des shaders d'attaque AVANT le HUD (pas d'impact sur les fenêtres UI)
+	if app.EffectRenderer != nil && app.World.Player != nil {
+		ratio := float32(app.World.Player.Stats.Sanity) / float32(app.World.Player.Stats.MaxSanity)
+
+		mx, my := ebiten.CursorPosition()
+		sw := float32(screen.Bounds().Dx())
+		sh := float32(screen.Bounds().Dy())
+
+		isOverPlaymat := float64(mx) >= ui.PlaymatX && float64(mx) < ui.PlaymatX+ui.PlaymatW &&
+			float64(my) >= ui.PlaymatY && float64(my) < ui.PlaymatY+ui.PlaymatH
+
+		attackParams := renderer.GlobalEffectParams{
+			SanityRatio: ratio,
+			UseBlur:     app.World.Player.VisualEffects["blur"] > 0 || app.World.Debug.ActiveShaders["blur"],
+			UseBubble:   (app.World.Player.VisualEffects["bubble"] > 0 || app.World.Debug.ActiveShaders["bubble"]) && isOverPlaymat,
+			UseVertige:  app.World.Player.VisualEffects["vertige"] > 0 || app.World.Debug.ActiveShaders["vertige"],
+			MousePos:    []float32{float32(mx) / sw, float32(my) / sh},
+			ScreenSize:  []float32{sw, sh},
+		}
+
+		app.EffectRenderer.ProcessCreatureAttackEffects(screen, attackParams)
 	}
 
-	// Application des shaders globaux (Biome + Attaques créatures + Sanité)
+	// HUD APRÈS les shaders d'attaque (pas d'impact visuel des attaques sur l'UI)
+	app.HUD.Render(screen)
+
+	// Shaders biome APRÈS le HUD (comportement original : affectent tout y compris les panneaux)
 	if app.EffectRenderer != nil && app.World.Player != nil {
 		ratio := float32(app.World.Player.Stats.Sanity) / float32(app.World.Player.Stats.MaxSanity)
 
@@ -1046,21 +1070,14 @@ func (app *Application) drawPlaying(screen *ebiten.Image) {
 			biome = string(grid.Biome)
 		}
 
-		mx, my := ebiten.CursorPosition()
 		sw := float32(screen.Bounds().Dx())
 		sh := float32(screen.Bounds().Dy())
 
-		// La bulle n'apparaît que sur le Playmat (700x700 à partir de ui.PlaymatX)
-		isOverPlaymat := float64(mx) >= ui.PlaymatX && float64(mx) < ui.PlaymatX+ui.PlaymatW &&
-			float64(my) >= ui.PlaymatY && float64(my) < ui.PlaymatY+ui.PlaymatH
-
 		// Recherche d'un portail portable déployé pour l'effet de vortex
-		// On n'affiche le vortex QUE si le timer de victoire est actif (portail en cours d'extraction)
 		var portalPos []float32
 		if grid != nil && app.Input.IsVictoryTimerActive() {
 			for _, e := range app.World.Entities.GetAllActive() {
 				if e.GetGridID() == grid.ID && e.HasTag("portable_portal") {
-					// Calcul de la position écran du centre de la tuile
 					px, py := app.Renderer.GetTileCenter(board.Position(e.GetPosition()), grid)
 					portalPos = []float32{float32(px) / sw, float32(py) / sh}
 					break
@@ -1068,26 +1085,25 @@ func (app *Application) drawPlaying(screen *ebiten.Image) {
 			}
 		}
 
-		params := renderer.GlobalEffectParams{
+		biomeParams := renderer.GlobalEffectParams{
 			SanityRatio: ratio,
 			Biome:       biome,
-			UseBlur:     app.World.Player.VisualEffects["blur"] > 0 || app.World.Debug.ActiveShaders["blur"],
-			UseBubble:   (app.World.Player.VisualEffects["bubble"] > 0 || app.World.Debug.ActiveShaders["bubble"]) && isOverPlaymat,
 			UseRain:     app.World.Player.VisualEffects["rain"] > 0 || app.World.Debug.ActiveShaders["rain"],
 			UseWave:     app.World.Debug.ActiveShaders["wave"],
 			UseHeat:     app.World.Debug.ActiveShaders["heat"],
 			UseCave:     app.World.Debug.ActiveShaders["cave"],
 			UseVortex:   app.World.Debug.ActiveShaders["vortex"],
 			PortalPos:   portalPos,
-			MousePos:    []float32{float32(mx) / sw, float32(my) / sh},
 			ScreenSize:  []float32{sw, sh},
 		}
 
-		app.EffectRenderer.ProcessGlobalEffects(screen, params)
+		app.EffectRenderer.ProcessBiomeEffects(screen, biomeParams)
 	}
 
-	// Ré-affiche le quake effect au-dessus des shaders globaux
-	app.Renderer.RenderQuakeOverlay(screen, app.World)
+	// DebugWindow APRÈS les shaders biome (pas traité par les shaders = meilleure performance avec F12)
+	if app.World.Debug.Visible {
+		app.DebugWindow.Render(screen)
+	}
 
 	if app.World.Entities.Count() == 0 {
 		textutil.Draw(screen, "Appuyez sur S pour spawner des entites", 200, 300, color.RGBA{255, 255, 0, 255})

--- a/internal/domain/README.md
+++ b/internal/domain/README.md
@@ -74,7 +74,7 @@ func (s *LifecycleSystem) Update(world *World) {
   - `Engine` : Orchestrateur des systèmes ECS.
   - `ECS Systems` : Implémentations (IA, Mouvement, Lifecycle, Loot...).
   - `AggressionSystem` : Gère le calcul modulaire de l'agressivité (Base + Facteurs : révélations, patience, inventaire, colère d'espèce). Déclenche les attaques à 100%.
-  - `CreatureAttackEffectSystem` : Centralise les effets mondiaux déclenchés par les attaques réussies (ex: rotation de grille, troubles cognitifs Aphasia/Ataxia/Agnosia/Amnesia).
+  - `CreatureAttackEffectSystem` : Centralise les effets mondiaux déclenchés par les attaques réussies (ex: rotation de grille, troubles cognitifs Aphasia/Ataxia/Agnosia/Amnesia/Vertigo).
   - `Mechanics` : Flip, Match, Merge.
   - `Navigation` : Gestion des grids et navigation.
   - `Entities` : Logique de spawn.
@@ -106,7 +106,7 @@ func (s *LifecycleSystem) Update(world *World) {
   - `ActionSystem` : Gère les actions spécifiques des créatures (ex: `spawn_trap` du Singe Mousse)
   - `TrackSystem` : Gère la durée de vie et la disparition progressive des traces au sol
   - `AggressionSystem` : **Nouveau** — Calcule l'agressivité totale des créatures (Base + Facteurs). S'abonne à `TileRevealed` (reason: "player_action") pour le facteur "reveals" et à `CreatureMoved` pour le facteur "patience" (+2% par pas, +10% par rebond). Déclenche l'attaque si agressivité ≥ 100 à la fin de l'animation de flip.
-  - `CreatureAttackEffectSystem` : Centralise les effets mondiaux des attaques réussies. Linke les impacts physiques aux altérations mentales (Aphasia, Ataxia, Agnosia, Amnesia) et transformations de terrain (Quake).
+  - `CreatureAttackEffectSystem` : Centralise les effets mondiaux des attaques réussies. Linke les impacts physiques aux altérations mentales (Aphasia, Ataxia, Agnosia, Amnesia, Vertigo) et transformations de terrain (Quake).
   - `ComboSystem` : Gère le système de combo (Priority 10). S'abonne à `TileMatched` pour incrémenter le compteur et calculer la juiciness (1-5). S'abonne à `TileMerged` pour publier un message sans incrémenter. S'abonne à `PlayerDamaged` pour réinitialiser le combo en cas d'erreur. Publie `ComboTriggered` via `PublishImmediate` (sinon perdu dans `ProcessQueue`).
 
 **Note architecture importante** : À partir de la fusion du #18, l'état visuel (`TileState`) appartient à l'entité, pas à la tuile. Cela permet :

--- a/internal/domain/component/component.go
+++ b/internal/domain/component/component.go
@@ -53,7 +53,10 @@ func (s *Store) Remove(entityID string, componentType string) {
 }
 
 func (s *Store) Has(entityID string, componentType string) bool {
-	_, ok := s.Get(entityID, componentType)
+	if s.components[entityID] == nil {
+		return false
+	}
+	_, ok := s.components[entityID][componentType]
 	return ok
 }
 
@@ -68,13 +71,16 @@ func (s *Store) GetAll(entityID string) []Component {
 	return result
 }
 
+// queryBuf est un buffer réutilisable pour QueryByComponent避免 les allocations.
+var queryBuf = make([]string, 0, 64)
+
 func (s *Store) QueryByComponent(componentType string) []string {
 	ids := s.byComponent[componentType]
-	result := make([]string, 0, len(ids))
+	queryBuf = queryBuf[:0]
 	for entityID := range ids {
-		result = append(result, entityID)
+		queryBuf = append(queryBuf, entityID)
 	}
-	return result
+	return queryBuf
 }
 
 func (s *Store) RemoveEntity(entityID string) {

--- a/internal/domain/player/player.go
+++ b/internal/domain/player/player.go
@@ -153,6 +153,7 @@ type Player struct {
 	AphasiaTurns int // Durée de l'aphasie (Echo Hound)
 	AtaxiaTurns  int // Durée de l'ataxie (Burrower)
 	AgnosiaTurns int // Durée de l'agnosie (Moss Monkey)
+	VertigoTurns int // Durée du vertige (Fleeing Sprite)
 
 	// Effets visuels (Shaders)
 	VisualEffects map[string]int // "blur", "bubble", etc. -> Durée en tours
@@ -618,6 +619,9 @@ func (p *Player) ConsumeSanity(amount int) {
 	}
 	if amount > 0 && p.AgnosiaTurns > 0 {
 		p.AgnosiaTurns--
+	}
+	if amount > 0 && p.VertigoTurns > 0 {
+		p.VertigoTurns--
 	}
 }
 

--- a/internal/domain/player/status.go
+++ b/internal/domain/player/status.go
@@ -9,6 +9,7 @@ const (
 	ImpairmentAgnosia   // Difficulté de reconnaissance visuelle
 	ImpairmentAtaxia    // Perturbation de la coordination / position
 	ImpairmentAmnesia   // Perturbation de la mémoire / séquence
+	ImpairmentVertigo   // Vertige / distorsion visuelle (Fleeing Sprite)
 )
 
 func (c CognitiveImpairment) String() string {
@@ -21,6 +22,8 @@ func (c CognitiveImpairment) String() string {
 		return "ataxia"
 	case ImpairmentAmnesia:
 		return "amnesia"
+	case ImpairmentVertigo:
+		return "vertigo"
 	default:
 		return "none"
 	}

--- a/internal/domain/system/aggression_system.go
+++ b/internal/domain/system/aggression_system.go
@@ -334,6 +334,8 @@ func (s *AggressionSystem) triggerExceededAttack(c *creature.Creature) {
 			s.world.Player.VisualEffects["blur"] = 3
 		} else if c.Species == "lumifly" {
 			s.world.Player.VisualEffects["bubble"] = 3
+		} else if c.Species == "fleeing_sprite" {
+			s.world.Player.VisualEffects["vertige"] = 3
 		}
 
 		// Publie l'événement de dégâts pour les retours HUD/Console

--- a/internal/domain/system/creature_effect_system.go
+++ b/internal/domain/system/creature_effect_system.go
@@ -89,5 +89,12 @@ func (s *CreatureAttackEffectSystem) onCreatureAttacked(e event.Event) {
 		if s.world.Player != nil {
 			s.world.Player.VisualEffects["bubble"] = 2
 		}
+
+	case "fleeing_sprite":
+		if s.world.Player != nil {
+			s.world.Player.VertigoTurns = 3
+			s.world.Player.VisualEffects["vertige"] = 3
+			s.world.EventBus.PublishImmediate(event.NewItemMessageEvent("Le monde tourne autour de vous..."))
+		}
 	}
 }

--- a/internal/ui/debug/window.go
+++ b/internal/ui/debug/window.go
@@ -184,6 +184,7 @@ func (dw *DebugWindow) renderImpairments(screen *ebiten.Image) {
 	dw.drawCheckbox(screen, startX, startY+120, "Ataxia (Burrower)", p.AtaxiaTurns > 0)
 	dw.drawCheckbox(screen, startX, startY+150, "Agnosia (Moss Monkey)", p.AgnosiaTurns > 0)
 	dw.drawCheckbox(screen, startX, startY+180, "Amnesia (Specter)", p.AmnesiaTurns > 0)
+	dw.drawCheckbox(screen, startX, startY+210, "Vertige (Fleeing Sprite)", dw.world.Debug.ActiveShaders["vertige"])
 }
 
 func (dw *DebugWindow) drawButton(screen *ebiten.Image, x, y float32, label, id string) {
@@ -399,6 +400,17 @@ func (dw *DebugWindow) handleClickImpairments(mx, my float32) {
 	if dw.isInside(mx, my, startX, startY+180, 200, 20) {
 		if p.AmnesiaTurns > 0 { p.AmnesiaTurns = 0 } else { p.AmnesiaTurns = 10 }
 	}
+	// Vertige
+	if dw.isInside(mx, my, startX, startY+210, 200, 20) {
+		dw.world.Debug.ActiveShaders["vertige"] = !dw.world.Debug.ActiveShaders["vertige"]
+		if dw.world.Player != nil {
+			if dw.world.Debug.ActiveShaders["vertige"] {
+				dw.world.Player.VisualEffects["vertige"] = 999
+			} else {
+				dw.world.Player.VisualEffects["vertige"] = 0
+			}
+		}
+	}
 }
 
 func (dw *DebugWindow) isInside(mx, my, x, y, w, h float32) bool {
@@ -414,6 +426,7 @@ func (dw *DebugWindow) ResetDefaults() {
 		dw.world.Player.AtaxiaTurns = 0
 		dw.world.Player.AgnosiaTurns = 0
 		dw.world.Player.AmnesiaTurns = 0
+		dw.world.Player.VertigoTurns = 0
 		dw.world.Player.VisualEffects = make(map[string]int)
 	}
 	dw.world.Debug.AllowedCreatures = map[string]bool{

--- a/internal/ui/renderer/effect_renderer.go
+++ b/internal/ui/renderer/effect_renderer.go
@@ -30,6 +30,8 @@ var (
 	rainShaderSource []byte
 	//go:embed shader/cave.kage
 	caveShaderSource []byte
+	//go:embed shader/vertige.kage
+	vertigeShaderSource []byte
 )
 
 type EffectRenderer struct {
@@ -57,6 +59,7 @@ func NewEffectRenderer() (*EffectRenderer, error) {
 		"lumifly": lumiflyShaderSource,
 		"rain":    rainShaderSource,
 		"cave":    caveShaderSource,
+		"vertige": vertigeShaderSource,
 	}
 
 	for name, src := range sources {
@@ -172,65 +175,31 @@ type GlobalEffectParams struct {
 	UseHeat     bool
 	UseCave     bool
 	UseVortex   bool
+	UseVertige  bool
 	PortalPos   []float32 // [x, y] normalized, nil if none
 	MousePos    []float32 // [x, y] normalized
 	ScreenSize  []float32 // [width, height] pixels
 }
 
-// ProcessGlobalEffects applique les effets cumulatifs sur l'image entière.
-func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params GlobalEffectParams) {
-	// L'intensité est nulle à Sanity 1.0 et max à 0.0.
+// ProcessCreatureAttackEffects applique les effets visuels d'attaque de créatures
+// (blur, bubble, vertige) sur l'image entière.
+// Doit être appelé AVANT le rendu du HUD pour ne pas affecter les fenêtres UI.
+func (r *EffectRenderer) ProcessCreatureAttackEffects(screen *ebiten.Image, params GlobalEffectParams) {
 	intensity := float32(math.Pow(float64(1.0-params.SanityRatio), 2))
 
-	// On vérifie si on doit appliquer des shaders même sans intensité de folie
-	shouldApply := intensity > 0 || params.UseBlur || params.UseBubble || params.UseRain || params.Biome != "" || params.PortalPos != nil || params.UseVortex
-
-	if !shouldApply {
+	if !params.UseBlur && !params.UseBubble && !params.UseVertige {
 		return
 	}
 
-	// On s'assure d'une intensité minimale pour que les shaders biome soient visibles
-	// même si la santé mentale est haute.
-	shaderIntensity := intensity
-	if shaderIntensity < 0.15 {
-		shaderIntensity = 0.15
-	}
+	r.ensureBuffers(screen)
 
-	// Redimensionnement dynamique des buffers si nécessaire
-	sw, sh := screen.Bounds().Dx(), screen.Bounds().Dy()
-	if r.bufferA.Bounds().Dx() != sw || r.bufferA.Bounds().Dy() != sh {
-		r.bufferA = ebiten.NewImage(sw, sh)
-		r.bufferB = ebiten.NewImage(sw, sh)
-	}
-
-	// Initialisation : on copie l'écran actuel dans Buffer A (Source)
-	// NOTE: Pas de ping-pong avec BlendCopy ici, on veut une source stable
 	r.bufferA.Clear()
 	r.bufferA.DrawImage(screen, nil)
 	src := r.bufferA
 	dst := r.bufferB
 
 	anyApplied := false
-	applyCave := params.Biome == "cave" || params.UseCave
 
-	// 1. Biome & Environmental Effects (Cumulative)
-	if params.Biome == "swamp" || params.UseWave {
-		r.applyShader(src, dst, "wave", shaderIntensity, nil, params.ScreenSize)
-		src, dst = dst, src
-		anyApplied = true
-	}
-	if params.Biome == "desert" || params.UseHeat {
-		r.applyShader(src, dst, "heat", shaderIntensity, nil, params.ScreenSize)
-		src, dst = dst, src
-		anyApplied = true
-	}
-	if params.Biome == "forest" || params.UseRain {
-		r.applyShader(src, dst, "rain", shaderIntensity, nil, params.ScreenSize)
-		src, dst = dst, src
-		anyApplied = true
-	}
-
-	// 2. Creature Attack Effects
 	if params.UseBubble {
 		bubbleMin := float32(0.45)
 		bubbleIntensity := bubbleMin + (1.0-bubbleMin)*intensity
@@ -247,11 +216,65 @@ func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params Globa
 		anyApplied = true
 	}
 
-	// 3. Special Static Effects (Vortex for Portal)
+	if params.UseVertige {
+		vertigeMin := float32(0.45)
+		vertigeIntensity := vertigeMin + (1.0-vertigeMin)*intensity
+		r.applyShader(src, dst, "vertige", vertigeIntensity, nil, params.ScreenSize)
+		src, dst = dst, src
+		anyApplied = true
+	}
+
+	if anyApplied {
+		op := &ebiten.DrawImageOptions{}
+		op.Blend = ebiten.BlendCopy
+		screen.DrawImage(src, op)
+	}
+}
+
+// ProcessBiomeEffects applique les effets de biome et environnementaux
+// (wave, heat, rain, cave, vortex) sur l'image entière.
+func (r *EffectRenderer) ProcessBiomeEffects(screen *ebiten.Image, params GlobalEffectParams) {
+	intensity := float32(math.Pow(float64(1.0-params.SanityRatio), 2))
+
+	shouldApply := intensity > 0 || params.UseRain || params.Biome != "" || params.PortalPos != nil || params.UseVortex
+	if !shouldApply {
+		return
+	}
+
+	shaderIntensity := intensity
+	if shaderIntensity < 0.15 {
+		shaderIntensity = 0.15
+	}
+
+	r.ensureBuffers(screen)
+
+	r.bufferA.Clear()
+	r.bufferA.DrawImage(screen, nil)
+	src := r.bufferA
+	dst := r.bufferB
+
+	anyApplied := false
+	applyCave := params.Biome == "cave" || params.UseCave
+
+	if params.Biome == "swamp" || params.UseWave {
+		r.applyShader(src, dst, "wave", shaderIntensity, nil, params.ScreenSize)
+		src, dst = dst, src
+		anyApplied = true
+	}
+	if params.Biome == "desert" || params.UseHeat {
+		r.applyShader(src, dst, "heat", shaderIntensity, nil, params.ScreenSize)
+		src, dst = dst, src
+		anyApplied = true
+	}
+	if params.Biome == "forest" || params.UseRain {
+		r.applyShader(src, dst, "rain", shaderIntensity, nil, params.ScreenSize)
+		src, dst = dst, src
+		anyApplied = true
+	}
+
 	if params.UseVortex || params.PortalPos != nil {
 		vortexCenter := params.PortalPos
 		if vortexCenter == nil && params.UseVortex {
-			// Mode debug : centre du playmat comme fallback
 			vortexCenter = []float32{
 				float32(ui.PlaymatX+ui.PlaymatW/2) / params.ScreenSize[0],
 				float32(ui.PlaymatY+ui.PlaymatH/2) / params.ScreenSize[1],
@@ -262,7 +285,6 @@ func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params Globa
 		anyApplied = true
 	}
 
-	// 4. Cave Shader (appliqué en DERNIER, cumulatif)
 	if applyCave {
 		hudLights := r.buildHudLights()
 		r.applyCaveShader(src, dst, shaderIntensity, params.ScreenSize, hudLights)
@@ -270,11 +292,19 @@ func (r *EffectRenderer) ProcessGlobalEffects(screen *ebiten.Image, params Globa
 		anyApplied = true
 	}
 
-	// Rendu final : On recopie le dernier Buffer (src) sur l'écran
 	if anyApplied {
 		op := &ebiten.DrawImageOptions{}
-		op.Blend = ebiten.BlendCopy // Remplace l'image sans superposition
+		op.Blend = ebiten.BlendCopy
 		screen.DrawImage(src, op)
+	}
+}
+
+// ensureBuffers redimensionne les buffers ping-pong si nécessaire.
+func (r *EffectRenderer) ensureBuffers(screen *ebiten.Image) {
+	sw, sh := screen.Bounds().Dx(), screen.Bounds().Dy()
+	if r.bufferA.Bounds().Dx() != sw || r.bufferA.Bounds().Dy() != sh {
+		r.bufferA = ebiten.NewImage(sw, sh)
+		r.bufferB = ebiten.NewImage(sw, sh)
 	}
 }
 

--- a/internal/ui/renderer/shader/vertige.kage
+++ b/internal/ui/renderer/shader/vertige.kage
@@ -1,0 +1,41 @@
+//kage:unit pixels
+
+package main
+
+var Time float
+var Intensity float
+var Resolution vec2
+
+func hash12(p vec2) float {
+	return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123)
+}
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	uv := dstPos.xy / Resolution
+	center := vec2(0.5, 0.5)
+	toCenter := uv - center
+	distFromCenter := length(toCenter)
+
+	distortion := 1.0 + distFromCenter*distFromCenter*0.4*Intensity
+
+	pulse := sin(Time*(2.0+5.0*Intensity)) * 0.03 * Intensity
+	distortion += pulse
+
+	uvDistorted := center + toCenter*distortion
+
+	chromaShift := 0.02 * Intensity * distFromCenter
+
+	texScale := srcPos / uv
+	srcPosR := (center + toCenter*(distortion+chromaShift)) * texScale
+	srcPosG := uvDistorted * texScale
+	srcPosB := (center + toCenter*(distortion-chromaShift)) * texScale
+
+	baseColor := vec4(
+		imageSrc0At(srcPosR).r,
+		imageSrc0At(srcPosG).g,
+		imageSrc0At(srcPosB).b,
+		1.0,
+	)
+
+	return baseColor
+}

--- a/internal/ui/textutil/textutil.go
+++ b/internal/ui/textutil/textutil.go
@@ -32,13 +32,16 @@ func init() {
 
 // Draw draws text at (x, y) with the given color.
 // y is treated as the baseline position (like text v1), not the top of the text.
+var sharedDrawOp = &text.DrawOptions{}
+
 func Draw(dst *ebiten.Image, str string, x, y int, clr color.Color) {
-	op := &text.DrawOptions{}
+	sharedDrawOp.GeoM.Reset()
 	// text v1 y was the baseline; text/v2 y is the top of the rendering region.
 	// Subtract ascent to convert baseline -> top-left.
-	op.GeoM.Translate(float64(x), float64(y)-Face.Metrics().HAscent)
-	op.ColorScale.ScaleWithColor(clr)
-	text.Draw(dst, str, Face, op)
+	sharedDrawOp.GeoM.Translate(float64(x), float64(y)-Face.Metrics().HAscent)
+	sharedDrawOp.ColorScale.Reset()
+	sharedDrawOp.ColorScale.ScaleWithColor(clr)
+	text.Draw(dst, str, Face, sharedDrawOp)
 }
 
 // MeasureWidth returns the width in pixels of the given text.


### PR DESCRIPTION
- shader vertige.kage: aberration chromatique + distorsion lens + pulsation panique
- ImpairmentVertigo + VertigoTurns avec decrementation
- CreatureEffectSystem: fleeing_sprite declenche vertige
- AggressionSystem: fleeing_sprite applique vertige en attack
- EffectRenderer: split attack/biome shaders
- Rendu: quake AVANT shaders, attack AVANT HUD, biome APRÈS HUD
- DebugWindow: separatee de HUD, rendue après biome shaders (perf F12)
- Perf: Has() inline, QueryByComponent queryBuf, textutil sharedDrawOp
- Docs: README, ARCHITECTURE, domain/README mis a jour