### PR TITLE
fix: reset engine state between games and deduplicate events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,7 +93,8 @@ Le domaine utilise une architecture **Entity-Component-System (ECS)** amélioré
   - **Cumul (Merge)** : Les entités peuvent être fusionnées pour augmenter leur `CumulationLevel` (0 à 2+). Cela influence les règles de match et le rendu (échelle x1.15 par niveau + bordures concentriques colorées si révélé).
 
 - **Systems** : Mettent à jour l'état du monde via l'**Engine** (`engine.go`).
-  - **Engine** : Chef d'orchestre du domaine. Il sépare la logique en deux cycles :
+  - **Engine** : Chef d'orchestre du domaine. Il sépare la logique en trois cycles :
+    - `Reset()` : Nettoie l'état interne de tous les systèmes (Previews, Mouvements, Combos) lors du démarrage d'une nouvelle session. Garantit qu'aucune donnée de la partie précédente ne persiste (ex: déclencheurs de mouvement des Stonewardens).
     - `Update()` : Cycle par tour (IA, maturation, fin de tour).
     - `UpdateFrame(dt)` : Cycle temps réel à 60 FPS (Timers, évènements UI, prévisualisation).
   - **CreatureAISystem** : Gère les comportements de base des créatures

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -519,8 +519,6 @@ func (app *Application) setupEventSubscriptions() {
 		gridID, ok4 := e.Payload["grid_id"].(string)
 		flipDir, ok5 := e.Payload["flip_direction"].(entity.FlipDirection)
 
-		fmt.Printf("[EVENT-DEBUG] TileRevealed reçu: ID=%s, Grid=%s, Pos=%v, Dir=%v\n", entityID, gridID, position, flipDir)
-
 		if ok1 && ok3 && ok4 && ok5 {
 			var entState entity.TileState
 			var startTrans, endTrans entity.Transformation
@@ -931,6 +929,7 @@ func (app *Application) StartGame() {
 
 	app.Input.ResetGameState()
 	app.HUD.ClearMessages()
+	app.World.RevealedBySpecies = make(map[string]int)
 
 	app.World.Turn = 0
 	app.World.MaxTurns = app.World.Player.Stats.MaxSanity
@@ -940,7 +939,7 @@ func (app *Application) StartGame() {
 	_ = app.World.AddLootItem(player.NewPortablePortalItem(0))
 	app.World.Player.Inventory.ScrollOffset = 0
 
-	app.Engine.ResetPreviews()
+	app.Engine.Reset()
 	fmt.Println("[ENGINE] Ready")
 
 	if app.World.TurnTimer != nil {
@@ -1050,6 +1049,7 @@ func (app *Application) drawPlaying(screen *ebiten.Image) {
 			UseBlur:     app.World.Player.VisualEffects["blur"] > 0 || app.World.Debug.ActiveShaders["blur"],
 			UseBubble:   (app.World.Player.VisualEffects["bubble"] > 0 || app.World.Debug.ActiveShaders["bubble"]) && isOverPlaymat,
 			UseVertige:  app.World.Player.VisualEffects["vertige"] > 0 || app.World.Debug.ActiveShaders["vertige"],
+			UseInvert:   app.World.Player.VisualEffects["invert"] > 0 || app.World.Debug.ActiveShaders["invert"],
 			MousePos:    []float32{float32(mx) / sw, float32(my) / sh},
 			ScreenSize:  []float32{sw, sh},
 		}

--- a/internal/domain/README.md
+++ b/internal/domain/README.md
@@ -93,7 +93,10 @@ func (s *LifecycleSystem) Update(world *World) {
   - `Behavior` : Composant IA enrichi — `AggressionBase` (statique), `Aggression` (total calculé), `AggressionFactors` (map[string]int : "reveals", "inventory", "species_anger", "empty_plots", "toxic_dreamberry"), `RevealCount` (compteur révélations manuelles).
 - **`component/`** : Stockage et définition des composants (`Store`)
 - **`world.go`** : Agrégateur de l'état global (Grids, Entities, Player).
-- **`engine.go`** : Orchestrateur des systèmes. Sépare le cycle par tour (`Update`) du cycle temps réel (`UpdateFrame`).
+- **`engine.go`** : Orchestrateur des systèmes. Sépare la logique en trois cycles :
+  - `Reset()` : Réinitialise l'état interne de tous les systèmes (Previews, Mouvements, Combos) lors du démarrage d'une nouvelle session. Garantit un état propre (ex: effacement des "révélations récentes" qui pourraient déclencher les Stonewardens).
+  - `Update()` : Cycle par tour.
+  - `UpdateFrame(dt)` : Cycle temps réel à 60 FPS.
 - **`system.go`** : Implémentation des systèmes ECS qui traitent les données.
   - `CreatureAISystem` : Gère les comportements de base des créatures
   - `CreatureMovementSystem` : Implémente le mouvement avancé avec triggers, navigation, modes. **Filtre les déclencheurs par grille** : `TriggerOnReveal`, `TriggerOnEcho`, `TriggerProximity` ne réagissent qu'aux événements sur la grille de la créature. Stocke les révélations avec `RevealedTile{Position, GridID}`. **Validation du swap** : Le mode `ModeSwap` est soumis à une validation bidirectionnelle avant exécution — retrait temporaire des deux entités, vérification `IsWalkable` (règles de cohabitation créature) et `HasResourceAt` (interdiction de doublon ressource). Si une validation échoue, le mouvement est annulé.

--- a/internal/domain/entity/entity.go
+++ b/internal/domain/entity/entity.go
@@ -750,35 +750,43 @@ func (m *Manager) GetByType(t Type) []Entity {
 		return m.cacheByType[t]
 	}
 
-	result := make([]Entity, 0, len(m.byType[t]))
+	// Réutilise la capacité du slice cache existant
+	cached := m.cacheByType[t]
+	if cached == nil {
+		cached = make([]Entity, 0, len(m.byType[t]))
+	}
+	cached = cached[:0]
 	for _, e := range m.byType[t] {
-		result = append(result, e)
+		cached = append(cached, e)
 	}
 	// Trie par ID pour avoir un ordre stable entre les frames
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].GetID() < result[j].GetID()
+	sort.Slice(cached, func(i, j int) bool {
+		return cached[i].GetID() < cached[j].GetID()
 	})
 
 	// Met à jour le cache
-	m.cacheByType[t] = result
+	m.cacheByType[t] = cached
 	m.dirtyTypes[t] = false
 
-	return result
+	return cached
 }
 
 func (m *Manager) GetAllActive() []Entity {
 	if !m.dirtyActive && m.activeCache != nil {
 		return m.activeCache
 	}
-	result := make([]Entity, 0)
+	// Réutilise la capacité du cache existant au lieu de créer un nouveau slice
+	if m.activeCache == nil {
+		m.activeCache = make([]Entity, 0, len(m.entities))
+	}
+	m.activeCache = m.activeCache[:0]
 	for _, e := range m.entities {
 		if e.IsActive() {
-			result = append(result, e)
+			m.activeCache = append(m.activeCache, e)
 		}
 	}
-	m.activeCache = result
 	m.dirtyActive = false
-	return result
+	return m.activeCache
 }
 
 func (m *Manager) QueryByTag(tag string) []Entity {

--- a/internal/domain/system/aggression_system.go
+++ b/internal/domain/system/aggression_system.go
@@ -336,6 +336,8 @@ func (s *AggressionSystem) triggerExceededAttack(c *creature.Creature) {
 			s.world.Player.VisualEffects["bubble"] = 3
 		} else if c.Species == "fleeing_sprite" {
 			s.world.Player.VisualEffects["vertige"] = 3
+		} else if c.Species == "flutterwing" {
+			s.world.Player.VisualEffects["invert"] = 3
 		}
 
 		// Publie l'événement de dégâts pour les retours HUD/Console

--- a/internal/domain/system/combo_system.go
+++ b/internal/domain/system/combo_system.go
@@ -58,13 +58,10 @@ func (s *ComboSystem) onMatch(e event.Event) {
 	s.lastMatchTurn = s.world.Turn
 	s.comboCount++
 
-	fmt.Printf("[COMBO] onMatch called! comboCount=%d, turn=%d, payload=%v\n", s.comboCount, s.world.Turn, e.Payload)
-
 	// Récupère les types d'association pour le bonus de synergie
 	assocTypes, _ := e.Payload["assoc_types"].([]string)
 	isSynergy := len(assocTypes) > 1
 
-	fmt.Printf("[COMBO] assocTypes=%v, isSynergy=%v\n", assocTypes, isSynergy)
 
 	// Calcul de la "Juiciness" (1 à 5)
 	juiciness := 1
@@ -99,7 +96,6 @@ func (s *ComboSystem) onMatch(e event.Event) {
 	s.world.Player.GainExperience(scoreBonus)
 
 	// Publie l'événement de combo
-	fmt.Printf("[COMBO] Publishing ComboTriggered: text=%q, count=%d, score=%d, juiciness=%d\n", msg, s.comboCount, scoreBonus, juiciness)
 	s.world.EventBus.PublishImmediate(event.NewComboTriggeredEvent(msg, s.comboCount, scoreBonus, juiciness))
 }
 

--- a/internal/domain/system/creature_effect_system.go
+++ b/internal/domain/system/creature_effect_system.go
@@ -96,5 +96,11 @@ func (s *CreatureAttackEffectSystem) onCreatureAttacked(e event.Event) {
 			s.world.Player.VisualEffects["vertige"] = 3
 			s.world.EventBus.PublishImmediate(event.NewItemMessageEvent("Le monde tourne autour de vous..."))
 		}
+
+	case "flutterwing":
+		if s.world.Player != nil {
+			s.world.Player.VisualEffects["invert"] = 2
+			s.world.EventBus.PublishImmediate(event.NewItemMessageEvent("Les couleurs s'inversent autour de vous..."))
+		}
 	}
 }

--- a/internal/domain/system/engine.go
+++ b/internal/domain/system/engine.go
@@ -75,11 +75,18 @@ func NewEngine(world *World) *Engine {
 	return e
 }
 
-// ResetPreviews réinitialise le suivi des prévisualisations (pour une nouvelle partie)
-func (e *Engine) ResetPreviews() {
+// Reset réinitialise tous les systèmes ayant un état interne (pour une nouvelle partie)
+func (e *Engine) Reset() {
 	if e.previewSystem != nil {
 		e.previewSystem.Reset()
 	}
+	if e.movementSystem != nil {
+		e.movementSystem.Reset()
+	}
+	if e.comboSystem != nil {
+		e.comboSystem.Reset()
+	}
+	e.hasMatchableEntities = true
 }
 
 // Update fait progresser le tour de jeu

--- a/internal/domain/system/engine_test.go
+++ b/internal/domain/system/engine_test.go
@@ -66,3 +66,27 @@ func TestEngineUpdateFrame(t *testing.T) {
 		t.Error("Timer should have reset after expiration")
 	}
 }
+
+func TestEngineReset(t *testing.T) {
+	w := NewWorld()
+	engine := NewEngine(w)
+
+	// Simulate state in systems
+	engine.movementSystem.TrackReveal(board.Position{X: 1, Y: 1}, "test")
+	engine.previewSystem.OnEnterGrid(w, "test")
+	engine.comboSystem.Reset() // Ensure it's in a known state (though it's already empty)
+	engine.comboSystem.CheatIncreaseCombo()
+
+	if len(engine.movementSystem.recentReveals) == 0 {
+		t.Error("movementSystem should have state")
+	}
+
+	engine.Reset()
+
+	if len(engine.movementSystem.recentReveals) != 0 {
+		t.Error("movementSystem state should be cleared after Reset")
+	}
+
+	// For PreviewSystem, we check if s.previewed is empty (indirectly via a second call)
+	// We'd need to expose more or check behavior.
+}

--- a/internal/domain/system/system.go
+++ b/internal/domain/system/system.go
@@ -40,12 +40,6 @@ func (s *LifecycleSystem) Update(world *World) {
 
 		if lifecycle.Progress() {
 			stageName := lifecycle.GetCurrentStageName()
-			ent, _ := world.Entities.Get(entity.ID(entityID))
-			entType := "unknown"
-			if ent != nil {
-				entType = ent.GetType().String()
-			}
-			fmt.Printf("[LIFECYCLE] Entité %s (%s) a mûri au stade %d: %s\n", entityID, entType, lifecycle.CurrentStage, stageName)
 			world.EventBus.Publish(event.NewResourceMaturedEvent(
 				entityID,
 				stageName,
@@ -54,7 +48,6 @@ func (s *LifecycleSystem) Update(world *World) {
 
 		if lifecycle.ShouldCycle() {
 			lifecycle.Cycle()
-			fmt.Printf("[LIFECYCLE] Entité %s a cyclé au stade 0\n", entityID)
 		}
 	}
 }
@@ -395,9 +388,6 @@ func (s *PreviewSystem) hideGrid(world *World, gridID string) {
 						_, _ = world.FlipTile(gridID, tile.Position, flipDir, "system_hide")
 						e.SetState(entity.Hidden | entity.Blocked)
 
-						world.EventBus.PublishImmediate(event.NewEntityRevealedEvent(
-							e.GetPosition(), string(e.GetID()), gridID, flipDir,
-							map[string]interface{}{"reason": "system_hide"}))
 						continue
 					}
 					continue
@@ -405,10 +395,6 @@ func (s *PreviewSystem) hideGrid(world *World, gridID string) {
 
 				if e.GetState()&entity.Revealed != 0 {
 					_, _ = world.FlipTile(gridID, tile.Position, tile.Tilt.ToFlipDirection(), "system_hide")
-
-					world.EventBus.PublishImmediate(event.NewEntityRevealedEvent(
-						e.GetPosition(), string(e.GetID()), gridID, tile.Tilt.ToFlipDirection(),
-						map[string]interface{}{"reason": "system_hide"}))
 				}
 			}
 		}
@@ -655,6 +641,7 @@ type RevealedTile struct {
 type CreatureMovementSystem struct {
 	world         *World
 	recentReveals []RevealedTile
+	reusableWA    worldAdapter // Reusable adapter to avoid per-call allocation
 }
 
 func NewCreatureMovementSystem(world *World) *CreatureMovementSystem {
@@ -689,6 +676,10 @@ func (s *CreatureMovementSystem) TrackReveal(pos board.Position, gridID string) 
 }
 
 func (s *CreatureMovementSystem) ClearReveals() {
+	s.recentReveals = s.recentReveals[:0]
+}
+
+func (s *CreatureMovementSystem) Reset() {
 	s.recentReveals = s.recentReveals[:0]
 }
 
@@ -810,8 +801,9 @@ func (s *CreatureMovementSystem) hasTarget(profile *creature.MovementProfile, c 
 	if !ok {
 		return false
 	}
-	wa := &worldAdapter{world: world, grid: grid}
-	target := wa.FindNearestTarget(c.GetPosition(), profile.Navigation.Target, profile.Navigation.TargetName, profile.Navigation.ExcludedStages)
+	s.reusableWA.world = world
+	s.reusableWA.setGrid(grid)
+	target := s.reusableWA.FindNearestTarget(c.GetPosition(), profile.Navigation.Target, profile.Navigation.TargetName, profile.Navigation.ExcludedStages)
 	return target != nil
 }
 
@@ -826,10 +818,11 @@ func (s *CreatureMovementSystem) executeWander(c *creature.Creature, profile *cr
 	})
 
 	currentPos := c.GetPosition()
+	s.reusableWA.world = world
+	s.reusableWA.setGrid(grid)
 	for _, dir := range directions {
 		newPos := entity.Position{X: currentPos.X + dir.X, Y: currentPos.Y + dir.Y}
-		wa := &worldAdapter{world: world, grid: grid}
-		if wa.IsWalkable(c, newPos) {
+		if s.reusableWA.IsWalkable(c, newPos) {
 			s.applyMoveMode(profile.Mode, c, currentPos, newPos, world, grid)
 			return
 		}
@@ -847,8 +840,9 @@ func sign(val int) int {
 }
 
 func (s *CreatureMovementSystem) executeMove(c *creature.Creature, profile *creature.MovementProfile, world *World, grid *board.Grid) bool {
-	wa := &worldAdapter{world: world, grid: grid}
-	direction := profile.Navigation.DecideDirection(wa, c)
+	s.reusableWA.world = world
+	s.reusableWA.setGrid(grid)
+	direction := profile.Navigation.DecideDirection(&s.reusableWA, c)
 	if direction == (entity.Position{X: 0, Y: 0}) {
 		return true
 	}
@@ -859,11 +853,11 @@ func (s *CreatureMovementSystem) executeMove(c *creature.Creature, profile *crea
 		Y: currentPos.Y + direction.Y,
 	}
 
-	if !wa.IsWalkable(c, newPos) {
+	if !s.reusableWA.IsWalkable(c, newPos) {
 		if profile.Navigation.Type == creature.NavOrientation {
 			dir := direction
-			hitH := !wa.IsWalkable(c, entity.Position{X: currentPos.X + dir.X, Y: currentPos.Y})
-			hitV := !wa.IsWalkable(c, entity.Position{X: currentPos.X, Y: currentPos.Y + dir.Y})
+			hitH := !s.reusableWA.IsWalkable(c, entity.Position{X: currentPos.X + dir.X, Y: currentPos.Y})
+			hitV := !s.reusableWA.IsWalkable(c, entity.Position{X: currentPos.X, Y: currentPos.Y + dir.Y})
 
 			rotateDegrees := 90
 			if hitH && hitV {
@@ -890,7 +884,7 @@ func (s *CreatureMovementSystem) executeMove(c *creature.Creature, profile *crea
 			return false
 		}
 
-		finalPos, success := profile.Collision.HandleCollision(wa, c, newPos)
+		finalPos, success := profile.Collision.HandleCollision(&s.reusableWA, c, newPos)
 		if !success {
 			return false
 		}
@@ -964,8 +958,9 @@ func (s *CreatureMovementSystem) MoveSpeciesOneStepTowards(species string, targe
 }
 
 func (s *CreatureMovementSystem) isWalkable(c *creature.Creature, pos entity.Position, grid *board.Grid, world *World) bool {
-	wa := &worldAdapter{world: world, grid: grid}
-	return wa.IsWalkable(c, pos)
+	s.reusableWA.world = world
+	s.reusableWA.setGrid(grid)
+	return s.reusableWA.IsWalkable(c, pos)
 }
 
 func (s *CreatureMovementSystem) handleCollision(coll creature.CollisionHandler, c *creature.Creature, newPos, currentPos entity.Position, world *World, grid *board.Grid) (entity.Position, bool) {
@@ -975,8 +970,9 @@ func (s *CreatureMovementSystem) handleCollision(coll creature.CollisionHandler,
 		}
 	}
 
-	wa := &worldAdapter{world: world, grid: grid}
-	return coll.HandleCollision(wa, c, newPos)
+	s.reusableWA.world = world
+	s.reusableWA.setGrid(grid)
+	return coll.HandleCollision(&s.reusableWA, c, newPos)
 }
 
 func (s *CreatureMovementSystem) applyMoveMode(mode creature.MovementMode, c *creature.Creature, oldPos, newPos entity.Position, world *World, grid *board.Grid) bool {
@@ -1130,6 +1126,11 @@ func directionToOrientation(dir entity.Position) creature.Orientation {
 type worldAdapter struct {
 	world *World
 	grid  *board.Grid
+}
+
+// setGrid updates the grid reference on a reusable adapter
+func (wa *worldAdapter) setGrid(g *board.Grid) {
+	wa.grid = g
 }
 
 func (wa *worldAdapter) GetPlayerPosition() entity.Position {

--- a/internal/domain/system/world_mechanics.go
+++ b/internal/domain/system/world_mechanics.go
@@ -12,7 +12,6 @@ import (
 
 // FlipTile bascule une entité entre caché et révélé et applique la transformation géométrique
 func (w *World) FlipTile(gridID string, pos board.Position, flipDir entity.FlipDirection, reason string) (entity.Entity, error) {
-	fmt.Printf("[WORLD-DEBUG] FlipTile appelé: Grid=%s, Pos=%v, Reason=%s\n", gridID, pos, reason)
 	grid, ok := w.Grids[gridID]
 	if !ok {
 		// Tentative de récupération via InventoryGrid si c'est l'ID réservé

--- a/internal/domain/system/world_navigation.go
+++ b/internal/domain/system/world_navigation.go
@@ -330,6 +330,7 @@ func (w *World) GenerateLayout(id string) {
 	w.GridOrder = make([]string, 0)
 	w.Entities = entity.NewManager() // Reset des entités
 	w.Components = component.NewStore()
+	w.RevealedBySpecies = make(map[string]int)
 
 	// Enregistre les zones dans World
 	// Priorité au début et à la fin
@@ -398,6 +399,7 @@ func (w *World) GeneratePlaytestLayout(id string) {
 	w.GridOrder = make([]string, 0)
 	w.Entities = entity.NewManager()
 	w.Components = component.NewStore()
+	w.RevealedBySpecies = make(map[string]int)
 
 	grid := w.DreamPlane.Zones[w.DreamPlane.StartZoneID]
 	w.Grids[grid.ID] = grid

--- a/internal/ui/debug/window.go
+++ b/internal/ui/debug/window.go
@@ -45,7 +45,7 @@ func (dw *DebugWindow) initCaches() {
 	sort.Strings(dw.sortedEntities)
 
 	// Shaders purement environnementaux (Biome)
-	dw.sortedShaders = []string{"cave", "heat", "rain", "vortex", "wave"}
+	dw.sortedShaders = []string{"cave", "heat", "rain", "wave"}
 	sort.Strings(dw.sortedShaders)
 }
 
@@ -185,6 +185,7 @@ func (dw *DebugWindow) renderImpairments(screen *ebiten.Image) {
 	dw.drawCheckbox(screen, startX, startY+150, "Agnosia (Moss Monkey)", p.AgnosiaTurns > 0)
 	dw.drawCheckbox(screen, startX, startY+180, "Amnesia (Specter)", p.AmnesiaTurns > 0)
 	dw.drawCheckbox(screen, startX, startY+210, "Vertige (Fleeing Sprite)", dw.world.Debug.ActiveShaders["vertige"])
+	dw.drawCheckbox(screen, startX, startY+240, "Invert (Flutterwing)", dw.world.Debug.ActiveShaders["invert"])
 }
 
 func (dw *DebugWindow) drawButton(screen *ebiten.Image, x, y float32, label, id string) {
@@ -408,6 +409,17 @@ func (dw *DebugWindow) handleClickImpairments(mx, my float32) {
 				dw.world.Player.VisualEffects["vertige"] = 999
 			} else {
 				dw.world.Player.VisualEffects["vertige"] = 0
+			}
+		}
+	}
+	// Invert
+	if dw.isInside(mx, my, startX, startY+240, 200, 20) {
+		dw.world.Debug.ActiveShaders["invert"] = !dw.world.Debug.ActiveShaders["invert"]
+		if dw.world.Player != nil {
+			if dw.world.Debug.ActiveShaders["invert"] {
+				dw.world.Player.VisualEffects["invert"] = 999
+			} else {
+				dw.world.Player.VisualEffects["invert"] = 0
 			}
 		}
 	}

--- a/internal/ui/hud/hud.go
+++ b/internal/ui/hud/hud.go
@@ -3,7 +3,6 @@ package hud
 
 import (
 	"fmt"
-	"image"
 	"image/color"
 	"math"
 	"sort"
@@ -64,6 +63,17 @@ type HUD struct {
 
 	inventoryOffscreen *ebiten.Image // Buffer pour le clipping de l'inventaire
 
+	// Pre-allocated overlay buffers for modal windows (avoid per-frame allocation)
+	overlayBuffer    *ebiten.Image // Full-screen overlay for modals
+	modalWindowCache *ebiten.Image // Cache for modal window background
+
+	// Pre-allocated offscreen buffers for message areas (clipping)
+	messageLeftBuffer  *ebiten.Image
+	messageRightBuffer *ebiten.Image
+
+	// Cached entity counts (reused across frames to avoid map allocation)
+	cachedDetailedCounts map[string]int
+
 	// NOUVEAU: Fenêtres de debug et difficulté
 	debugWindow   *dbg.DebugWindow
 	DiffSelection *DifficultySelection
@@ -82,15 +92,20 @@ type HUD struct {
 	queueLeft     []string
 	queueRight    []string
 	activeLeft    *NotificationMessage
-	activeRight          *NotificationMessage
-	toxicIntensity       float64 // Intensité de la toxicité pour le feedback visuel
-	lastToxicTurn        int     // Dernier tour où on a reçu des dégâts de poison
+	activeRight   *NotificationMessage
+	toxicIntensity float64 // Intensité de la toxicité pour le feedback visuel
+	lastToxicTurn  int     // Dernier tour où on a reçu des dégâts de poison
 
 	// Combo Juicy
 	comboMsg *ComboMessage
 
 	// Navigation des stades dans l'atlas des assets
 	resourceStageIndex map[string]int
+
+	// Cached sorted keys for grid counts
+	cachedGridCountsKeys []string
+	cachedGridCountsGrid string
+	cachedGridCountsTurn int
 }
 
 // NewHUD crée un nouveau HUD
@@ -104,6 +119,12 @@ func NewHUD(world *domain.World) *HUD {
 		showVictory:          false,
 		fullFeedbackTimer:    0,
 		inventoryOffscreen:   ebiten.NewImage(int(ui.InventoryW), 331),
+		// Pre-allocate overlay buffers for modal windows
+		overlayBuffer:    ebiten.NewImage(ui.ScreenWidth, ui.ScreenHeight),
+		modalWindowCache: ebiten.NewImage(800, 500), // Max modal size
+		// Pre-allocate offscreen buffers for message area clipping
+		messageLeftBuffer:  ebiten.NewImage(ui.MessageBoxWLeft, ui.MessageBoxHLeft),
+		messageRightBuffer: ebiten.NewImage(ui.MessageBoxWRight, ui.MessageBoxHRight),
 		selectedLoots:        make(map[int]bool),
 		selectedLootIndex:    -1,
 		confirmClearAll:      false,
@@ -112,6 +133,7 @@ func NewHUD(world *domain.World) *HUD {
 		queueLeft:            make([]string, 0),
 		queueRight:           make([]string, 0),
 		resourceStageIndex:   make(map[string]int),
+		cachedDetailedCounts: make(map[string]int),
 	}
 
 	// S'abonne aux événements d'inventaire plein
@@ -170,8 +192,6 @@ func NewHUD(world *domain.World) *HUD {
 		txt, _ := e.Payload["text"].(string)
 		count, _ := e.Payload["count"].(int)
 		juiciness, _ := e.Payload["juiciness"].(int)
-
-		fmt.Printf("[HUD] ComboTriggered received! text=%q, count=%d, juiciness=%d\n", txt, count, juiciness)
 
 		h.comboMsg = &ComboMessage{
 			Text:        txt,
@@ -447,33 +467,32 @@ func (h *HUD) Render(screen *ebiten.Image) {
 func (h *HUD) renderMessageArea(screen *ebiten.Image, area string) {
 	var x, y, w, hBox float64
 	var active *NotificationMessage
+	var buf *ebiten.Image
 
 	if area == "left" {
 		x, y, w, hBox = ui.MessageBoxXLeft, ui.MessageBoxYLeft, ui.MessageBoxWLeft, ui.MessageBoxHLeft
 		active = h.activeLeft
+		buf = h.messageLeftBuffer
 	} else {
 		x, y, w, hBox = ui.MessageBoxXRight, ui.MessageBoxYRight, ui.MessageBoxWRight, ui.MessageBoxHRight
 		active = h.activeRight
+		buf = h.messageRightBuffer
 	}
 
-	// 1. Fond de la boîte de message
-	vector.DrawFilledRect(screen, float32(x), float32(y), float32(w), float32(hBox), color.RGBA{20, 20, 30, 180}, true)
-	vector.StrokeRect(screen, float32(x), float32(y), float32(w), float32(hBox), 1, color.RGBA{100, 100, 150, 100}, true)
+	// Draw background + text to offscreen buffer (automatic clipping at buffer edges)
+	buf.Fill(color.RGBA{20, 20, 30, 180})
+	vector.StrokeRect(buf, 0, 0, float32(w), float32(hBox), 1, color.RGBA{100, 100, 150, 100}, true)
 
-	if active == nil {
-		return
+	if active != nil {
+		ty := (hBox / 2) + 5
+		// Position relative to buffer origin — anything outside [0, w] is clipped
+		textutil.Draw(buf, active.Text, int(active.X), int(ty), color.RGBA{255, 255, 230, 255})
 	}
 
-    // 2. Texte défilant (avec clipping)
-    // On crée une sous-image pour le clipping (le repère reste celui de 'screen')
-    rect := image.Rect(int(x), int(y), int(x+w), int(y+hBox))
-    msgImg := screen.SubImage(rect).(*ebiten.Image)
-
-    // Calcul de la position Y centrée (relative à l'écran, donc on ajoute 'y')
-    ty := y + (hBox / 2) + 5
-
-    // On dessine sur msgImg en coordonnées absolues (repère screen)
-    textutil.Draw(msgImg, active.Text, int(x+active.X), int(ty), color.RGBA{255, 255, 230, 255})
+	// Blit buffer to screen at message box position
+	op := &ebiten.DrawImageOptions{}
+	op.GeoM.Translate(x, y)
+	screen.DrawImage(buf, op)
 }
 
 func (h *HUD) renderJuicyCombo(screen *ebiten.Image) {
@@ -492,9 +511,6 @@ func (h *HUD) renderJuicyCombo(screen *ebiten.Image) {
 	// Position dans la combo zone (au-dessus des jauges)
 	baseX := ui.ComboZoneX + ui.ComboZoneW/2
 	baseY := ui.ComboZoneY + ui.ComboZoneH/2 + ui.ComboTextOffY + h.comboMsg.YOffset
-
-	fmt.Printf("[HUD] renderJuicyCombo: text=%q, baseX=%.1f, baseY=%.1f, timer=%d, juiciness=%d\n",
-		h.comboMsg.Text, float64(baseX), baseY, h.comboMsg.Timer, h.comboMsg.Juiciness)
 
 	// Fond coloré selon juiciness
 	var bgClr color.RGBA
@@ -604,10 +620,10 @@ func hsvToRgb(h, s, v float64) color.RGBA {
 
 // renderAssetsWindow dessine une fenêtre montrant tous les assets chargés
 func (h *HUD) renderAssetsWindow(screen *ebiten.Image) {
-	// Fond semi-transparent couvrant l'aire de jeu
-	overlay := ebiten.NewImage(ui.ScreenWidth, ui.ScreenHeight)
-	overlay.Fill(color.RGBA{0, 0, 0, 200})
-	screen.DrawImage(overlay, nil)
+	// Fond semi-transparent couvrant l'aire de jeu - use pre-allocated buffer
+	h.overlayBuffer.Clear()
+	h.overlayBuffer.Fill(color.RGBA{0, 0, 0, 200})
+	screen.DrawImage(h.overlayBuffer, nil)
 
 	// Fenêtre centrale
 	winW, winH := 800, 500
@@ -778,9 +794,8 @@ func (h *HUD) drawButton(screen *ebiten.Image, x, y, w, buttonH float32, label s
 
 // renderVictoryWindow dessine l'écran de victoire
 func (h *HUD) renderVictoryWindow(screen *ebiten.Image) {
-	overlay := ebiten.NewImage(ui.ScreenWidth, ui.ScreenHeight)
-	overlay.Fill(color.RGBA{0, 0, 0, 220})
-	screen.DrawImage(overlay, nil)
+	// Use vector.DrawFilledRect for overlay instead of creating new image
+	vector.DrawFilledRect(screen, 0, 0, float32(ui.ScreenWidth), float32(ui.ScreenHeight), color.RGBA{0, 0, 0, 220}, true)
 
 	winW, winH := 600, 400
 	x := (ui.ScreenWidth - winW) / 2
@@ -884,13 +899,16 @@ func (h *HUD) HandleGameOverClick(mx, my int) string {
 
 // getGridDetailedCounts retourne le nombre d'entités par type/espèce pour une grille donnée
 func (h *HUD) getGridDetailedCounts(gridID string) map[string]int {
-	counts := make(map[string]int)
+	// Reuse cached map instead of allocating a new one each frame
+	for k := range h.cachedDetailedCounts {
+		delete(h.cachedDetailedCounts, k)
+	}
 
 	// Ressources
 	for _, e := range h.world.Entities.GetByType(entity.TypeResource) {
 		if e.GetGridID() == gridID && e.GetState() != entity.Matched {
 			if r, ok := e.(*domain.Resource); ok {
-				counts[r.ResourceType]++
+				h.cachedDetailedCounts[r.ResourceType]++
 			}
 		}
 	}
@@ -898,7 +916,7 @@ func (h *HUD) getGridDetailedCounts(gridID string) map[string]int {
 	for _, e := range h.world.Entities.GetByType(entity.TypeCreature) {
 		if e.GetGridID() == gridID && e.GetState() != entity.Matched {
 			if c, ok := e.(*domain.Creature); ok {
-				counts[c.Species]++
+				h.cachedDetailedCounts[c.Species]++
 			}
 		}
 	}
@@ -915,10 +933,10 @@ func (h *HUD) getGridDetailedCounts(gridID string) map[string]int {
 			} else if e.HasTag("obelisk") {
 				label = "obelisque"
 			}
-			counts[label]++
+			h.cachedDetailedCounts[label]++
 		}
 	}
-	return counts
+	return h.cachedDetailedCounts
 }
 
 // getGridEntityCounts retourne le nombre total de ressources, créatures et structures sur un grid

--- a/internal/ui/renderer/board_renderer.go
+++ b/internal/ui/renderer/board_renderer.go
@@ -264,7 +264,6 @@ func (r *BoardRenderer) ClearDebugReveal() {
 // StartFlipAnimation démarre une animation de flip pour une tuile
 func (r *BoardRenderer) StartFlipAnimation(gridID string, pos board.Position, flipDir entity.FlipDirection, entityID string, finalState entity.TileState, startTrans, endTrans entity.Transformation) {
 	key := gridID + ":" + fmt.Sprint(pos.X) + "," + fmt.Sprint(pos.Y) + ":" + entityID
-	fmt.Printf("[ANIM-DEBUG] StartFlipAnimation: Key=%s, Dir=%v, State=%s\n", key, flipDir, finalState.String())
 	r.flipAnimations[key] = &FlipAnimation{
 		GridID:         gridID,
 		Position:       pos,

--- a/internal/ui/renderer/effect_renderer.go
+++ b/internal/ui/renderer/effect_renderer.go
@@ -32,6 +32,8 @@ var (
 	caveShaderSource []byte
 	//go:embed shader/vertige.kage
 	vertigeShaderSource []byte
+	//go:embed shader/invert.kage
+	invertShaderSource []byte
 )
 
 type EffectRenderer struct {
@@ -60,6 +62,7 @@ func NewEffectRenderer() (*EffectRenderer, error) {
 		"rain":    rainShaderSource,
 		"cave":    caveShaderSource,
 		"vertige": vertigeShaderSource,
+		"invert":  invertShaderSource,
 	}
 
 	for name, src := range sources {
@@ -176,6 +179,7 @@ type GlobalEffectParams struct {
 	UseCave     bool
 	UseVortex   bool
 	UseVertige  bool
+	UseInvert   bool
 	PortalPos   []float32 // [x, y] normalized, nil if none
 	MousePos    []float32 // [x, y] normalized
 	ScreenSize  []float32 // [width, height] pixels
@@ -187,7 +191,7 @@ type GlobalEffectParams struct {
 func (r *EffectRenderer) ProcessCreatureAttackEffects(screen *ebiten.Image, params GlobalEffectParams) {
 	intensity := float32(math.Pow(float64(1.0-params.SanityRatio), 2))
 
-	if !params.UseBlur && !params.UseBubble && !params.UseVertige {
+	if !params.UseBlur && !params.UseBubble && !params.UseVertige && !params.UseInvert {
 		return
 	}
 
@@ -220,6 +224,14 @@ func (r *EffectRenderer) ProcessCreatureAttackEffects(screen *ebiten.Image, para
 		vertigeMin := float32(0.45)
 		vertigeIntensity := vertigeMin + (1.0-vertigeMin)*intensity
 		r.applyShader(src, dst, "vertige", vertigeIntensity, nil, params.ScreenSize)
+		src, dst = dst, src
+		anyApplied = true
+	}
+
+	if params.UseInvert {
+		invertMin := float32(0.5)
+		invertIntensity := invertMin + (1.0-invertMin)*intensity
+		r.applyShader(src, dst, "invert", invertIntensity, nil, params.ScreenSize)
 		src, dst = dst, src
 		anyApplied = true
 	}

--- a/internal/ui/renderer/shader/invert.kage
+++ b/internal/ui/renderer/shader/invert.kage
@@ -1,0 +1,93 @@
+//kage:unit pixels
+
+package main
+
+var Time float
+var Intensity float
+
+func rgb2hsl(c vec3) vec3 {
+	maxVal := max(c.r, max(c.g, c.b))
+	minVal := min(c.r, min(c.g, c.b))
+	l := (maxVal + minVal) / 2.0
+	h, s := 0.0, 0.0
+
+	if maxVal != minVal {
+		d := maxVal - minVal
+		if l > 0.5 {
+			s = d / (2.0 - maxVal - minVal)
+		} else {
+			s = d / (maxVal + minVal)
+		}
+
+		if maxVal == c.r {
+			h = (c.g - c.b) / d
+			if c.g < c.b {
+				h += 6.0
+			}
+		} else if maxVal == c.g {
+			h = (c.b - c.r) / d + 2.0
+		} else {
+			h = (c.r - c.g) / d + 4.0
+		}
+		h /= 6.0
+	}
+	return vec3(h, s, l)
+}
+
+func hue2rgb(p, q, t float) float {
+	if t < 0.0 {
+		t += 1.0
+	}
+	if t > 1.0 {
+		t -= 1.0
+	}
+	if t < 1.0/6.0 {
+		return p + (q-p)*6.0*t
+	}
+	if t < 1.0/2.0 {
+		return q
+	}
+	if t < 2.0/3.0 {
+		return p + (q-p)*(2.0/3.0-t)*6.0
+	}
+	return p
+}
+
+func hsl2rgb(c vec3) vec3 {
+	r, g, b := 0.0, 0.0, 0.0
+	if c.y == 0.0 {
+		r, g, b = c.z, c.z, c.z
+	} else {
+		q, p := 0.0, 0.0
+		if c.z < 0.5 {
+			q = c.z * (1.0 + c.y)
+		} else {
+			q = c.z + c.y - c.z*c.y
+		}
+		p = 2.0*c.z - q
+		r = hue2rgb(p, q, c.x+1.0/3.0)
+		g = hue2rgb(p, q, c.x)
+		b = hue2rgb(p, q, c.x-1.0/3.0)
+	}
+	return vec3(r, g, b)
+}
+
+func Fragment(dstPos vec4, srcPos vec2, color vec4) vec4 {
+	clr := imageSrc0At(srcPos)
+
+	if clr.a == 0.0 {
+		return clr
+	}
+
+	hsl := rgb2hsl(clr.rgb)
+
+	hueShift := 0.5
+	hueShift += 0.2 * sin(Time*2.0)
+	psychosedelicHue := fract(hsl.x + hueShift)
+
+	psychosedelicHSL := vec3(psychosedelicHue, hsl.y, hsl.z)
+	psychosedelicRGB := hsl2rgb(psychosedelicHSL)
+
+	inverted := vec4(psychosedelicRGB, clr.a)
+	return mix(clr, inverted, Intensity)
+}


### PR DESCRIPTION
- Implemented Engine.Reset() to clear internal states of all systems (Movement, Previews, Combos)
- Fixed Stonewarden premature movement by resetting CreatureMovementSystem memory
- Reset RevealedBySpecies in GeneratePlaytestLayout and StartGame to ensure accurate aggression levels
- Removed redundant TileRevealed events in hideGrid logic
- Updated ARCHITECTURE.md and Domain README to document the new Reset cycle
- Includes various UI and entity updates from the current refactor branch